### PR TITLE
Drop Ruby 3.1 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ['3.1', '3.2', '3.3', '3.4']
+        ruby: ['3.2', '3.3', '3.4']
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+### Added
+- Drop support for Ruby 3.1
 
 ## [0.1.0] - 2025-07-19
 

--- a/image_util.gemspec
+++ b/image_util.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Provides Color and Image classes for manipulating raw image data and converting buffers to standard formats.'
   spec.homepage = "https://github.com/rbutils/image_util"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 


### PR DESCRIPTION
## Summary
- drop Ruby 3.1 from CI workflow and Rubocop
- require Ruby >= 3.2 in gemspec
- mention dropped support in CHANGELOG

## Testing
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_687cb62fa0a8832a892a1a5b37904eec