### PR TITLE
Implement Color overlay with alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Features include:
 * A `Color` helper class capable of parsing numbers, arrays and HTML style strings.
 * Conversion of an image to PAM or SIXEL for quick previews in compatible terminals.
 * Convenience methods for iterating over pixel locations and setting values.
+* Overlaying colors with the `+` operator which blends using the alpha channel.
 
 ## Installation
 

--- a/lib/image_util/color.rb
+++ b/lib/image_util/color.rb
@@ -116,23 +116,21 @@ module ImageUtil
 
     # Overlays another color on top of this one taking the alpha
     # channel of both colors into account.
-    def +(other)
-      other = Color.from(other)
+      def +(other)
+        other = Color.from(other)
 
-      base_a   = a.to_f / 255
-      over_a   = other.a.to_f / 255
+        base_a = a.to_f / 255
+        over_a = other.a.to_f / 255
 
-      out_a = over_a + base_a * (1 - over_a)
+        out_a = over_a + base_a * (1 - over_a)
 
-      if out_a.zero?
-        return Color.new(0, 0, 0, 0)
+        return Color.new(0, 0, 0, 0) if out_a.zero?
+
+        out_r = (other.r * over_a + r * base_a * (1 - over_a)) / out_a
+        out_g = (other.g * over_a + g * base_a * (1 - over_a)) / out_a
+        out_b = (other.b * over_a + b * base_a * (1 - over_a)) / out_a
+
+        Color.new(out_r, out_g, out_b, out_a * 255)
       end
-
-      out_r = (other.r * over_a + r * base_a * (1 - over_a)) / out_a
-      out_g = (other.g * over_a + g * base_a * (1 - over_a)) / out_a
-      out_b = (other.b * over_a + b * base_a * (1 - over_a)) / out_a
-
-      Color.new(out_r.round, out_g.round, out_b.round, (out_a * 255).round)
-    end
   end
 end

--- a/lib/image_util/color.rb
+++ b/lib/image_util/color.rb
@@ -113,5 +113,26 @@ module ImageUtil
     end
 
     alias eql? ==
+
+    # Overlays another color on top of this one taking the alpha
+    # channel of both colors into account.
+    def +(other)
+      other = Color.from(other)
+
+      base_a   = a.to_f / 255
+      over_a   = other.a.to_f / 255
+
+      out_a = over_a + base_a * (1 - over_a)
+
+      if out_a.zero?
+        return Color.new(0, 0, 0, 0)
+      end
+
+      out_r = (other.r * over_a + r * base_a * (1 - over_a)) / out_a
+      out_g = (other.g * over_a + g * base_a * (1 - over_a)) / out_a
+      out_b = (other.b * over_a + b * base_a * (1 - over_a)) / out_a
+
+      Color.new(out_r.round, out_g.round, out_b.round, (out_a * 255).round)
+    end
   end
 end

--- a/lib/image_util/color.rb
+++ b/lib/image_util/color.rb
@@ -116,21 +116,21 @@ module ImageUtil
 
     # Overlays another color on top of this one taking the alpha
     # channel of both colors into account.
-      def +(other)
-        other = Color.from(other)
+    def +(other)
+      other = Color.from(other)
 
-        base_a = a.to_f / 255
-        over_a = other.a.to_f / 255
+      base_a = a.to_f / 255
+      over_a = other.a.to_f / 255
 
-        out_a = over_a + base_a * (1 - over_a)
+      out_a = over_a + base_a * (1 - over_a)
 
-        return Color.new(0, 0, 0, 0) if out_a.zero?
+      return Color.new(0, 0, 0, 0) if out_a.zero?
 
-        out_r = (other.r * over_a + r * base_a * (1 - over_a)) / out_a
-        out_g = (other.g * over_a + g * base_a * (1 - over_a)) / out_a
-        out_b = (other.b * over_a + b * base_a * (1 - over_a)) / out_a
+      out_r = (other.r * over_a + r * base_a * (1 - over_a)) / out_a
+      out_g = (other.g * over_a + g * base_a * (1 - over_a)) / out_a
+      out_b = (other.b * over_a + b * base_a * (1 - over_a)) / out_a
 
-        Color.new(out_r, out_g, out_b, out_a * 255)
-      end
+      Color.new(out_r, out_g, out_b, out_a * 255)
+    end
   end
 end

--- a/spec/color_spec.rb
+++ b/spec/color_spec.rb
@@ -85,4 +85,10 @@ RSpec.describe ImageUtil::Color do
   it 'raises on bad array values' do
     ->{ ImageUtil::Color.from([Object.new]) }.should raise_error(ArgumentError)
   end
+
+  it 'overlays colors with +' do
+    base = ImageUtil::Color[0, 0, 255]
+    overlay = ImageUtil::Color[255, 0, 0, 128]
+    (base + overlay).should == ImageUtil::Color[128, 0, 127, 255]
+  end
 end

--- a/spec/color_spec.rb
+++ b/spec/color_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ImageUtil::Color do
 
   it 'overlays colors with +' do
     base = ImageUtil::Color[0, 0, 255]
-    overlay = ImageUtil::Color[255, 0, 0, 128]
-    (base + overlay).should == ImageUtil::Color[128, 0, 127, 255]
+    overlay = ImageUtil::Color[255, 0, 0, 0.5]
+    (base + overlay).should == ImageUtil::Color.new(127.5, 0, 127.5, 255)
   end
 end


### PR DESCRIPTION
## Summary
- add overlay behavior for `ImageUtil::Color` via `+` operator
- document color overlay support in README
- test color overlay logic

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_687cb9699900832aaba07c83a98fda12