### PR TITLE
Add Ruby SIXEL encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 - Drop support for Ruby 3.1
+- Native SIXEL encoder
 
 ## [0.1.0] - 2025-07-19
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Features include:
 * Support for 8, 16 or 32 bit components and RGB or RGBA color values.
 * A `Color` helper class capable of parsing numbers, arrays and HTML style strings.
 * Conversion of an image to PAM or SIXEL for quick previews in compatible terminals.
+* Built-in SIXEL encoder that works without ImageMagick.
 * Convenience methods for iterating over pixel locations and setting values.
 * Overlaying colors with the `+` operator which blends using the alpha channel.
 

--- a/lib/image_util/codec.rb
+++ b/lib/image_util/codec.rb
@@ -57,5 +57,6 @@ module ImageUtil
     require_relative "codec/libpng"
     require_relative "codec/pam"
     require_relative "codec/image_magick"
+    require_relative "codec/ruby_sixel"
   end
 end

--- a/lib/image_util/codec/ruby_sixel.rb
+++ b/lib/image_util/codec/ruby_sixel.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module ImageUtil
+  module Codec
+    module RubySixel
+      SUPPORTED_FORMATS = [:sixel].freeze
+
+      module_function
+
+      def supported?(format = nil)
+        return true if format.nil?
+
+        SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+      end
+
+      def encode(_format, image)
+        unless image.dimensions.length == 2
+          raise ArgumentError, "only 2D images supported"
+        end
+
+        unless image.color_bits == 8
+          raise ArgumentError, "only 8-bit colors supported"
+        end
+
+        img = image.dither(256)
+
+        palette = []
+        palette_map = {}
+        img.each_pixel do |color|
+          key = color.to_a
+          next if palette_map.key?(key)
+
+          palette_map[key] = palette.length
+          palette << color
+        end
+
+        out = "\ePq".dup
+        palette.each_with_index do |c, idx|
+          out << format("#%d;2;%d;%d;%d", idx, c.r * 100 / 255, c.g * 100 / 255, c.b * 100 / 255)
+        end
+
+        height = img.height || 1
+        width = img.width || 1
+
+        (0...height).step(6) do |y|
+          palette.each_with_index do |_c, idx|
+            out << "##{idx}"
+            run_char = nil
+            run_len = 0
+            (0...width).each do |x|
+              bits = 0
+              6.times do |i|
+                yy = y + i
+                if yy < height && palette_map[img[x, yy].to_a] == idx
+                  bits |= 1 << i
+                end
+              end
+              char = (63 + bits).chr
+              if char == run_char
+                run_len += 1
+              else
+                out << "!#{run_len}" << run_char if run_len > 1
+                out << run_char if run_len == 1
+                run_char = char
+                run_len = 1
+              end
+            end
+            out << "!#{run_len}" << run_char if run_len > 1
+            out << run_char if run_len == 1
+            out << "$"
+          end
+          out << "-"
+        end
+
+        out << "\e\\"
+        out
+      end
+
+      def encode_io(format, image, io)
+        io << encode(format, image)
+      end
+
+      def decode(*)
+        raise UnsupportedFormatError, "decode not supported for sixel"
+      end
+
+      def decode_io(*)
+        raise UnsupportedFormatError, "decode not supported for sixel"
+      end
+
+      Codec.register(:ruby_sixel, self)
+      Codec.register(:sixel, self) unless ImageMagick.supported?(:sixel)
+    end
+  end
+end

--- a/spec/codec/ruby_sixel_spec.rb
+++ b/spec/codec/ruby_sixel_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Codec::RubySixel do
+  it 'encodes an image to sixel' do
+    img = ImageUtil::Image.new(2, 1) { |x, _| ImageUtil::Color[x * 255, 0, 0] }
+    data = described_class.encode(:sixel, img)
+    data.start_with?("\ePq").should be true
+    data.end_with?("\e\\").should be true
+    data.include?('#0;2;100;0;0').should be true
+  end
+end

--- a/spec/codec/ruby_sixel_spec.rb
+++ b/spec/codec/ruby_sixel_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe ImageUtil::Codec::RubySixel do
     data = described_class.encode(:sixel, img)
     data.start_with?("\ePq").should be true
     data.end_with?("\e\\").should be true
-    data.include?('#0;2;100;0;0').should be true
+    data.match?(/#\d+;2;100;0;0/).should be true
   end
 end


### PR DESCRIPTION
## Summary
- implement a pure Ruby SIXEL encoder using Image#dither
- load codec when ImageMagick support is missing
- expose codec as :ruby_sixel
- document native SIXEL support

## Testing
- `bundle exec rake` *(fails: Could not find gem 'rspec (~> 3.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_687cf6aabe28832a8832b6321d3c6583