### PR TITLE
Add Color#* for alpha scaling

### DIFF
--- a/lib/image_util/color.rb
+++ b/lib/image_util/color.rb
@@ -138,5 +138,12 @@ module ImageUtil
 
       Color.new(out_r, out_g, out_b, out_a * 255)
     end
+
+    # Multiplies the alpha channel by the given factor and returns a new color.
+    def *(other)
+      raise TypeError, "factor must be numeric" unless other.is_a?(Numeric)
+
+      Color.new(r, g, b, (a * other).clamp(0, 255))
+    end
   end
 end

--- a/spec/color_spec.rb
+++ b/spec/color_spec.rb
@@ -91,4 +91,8 @@ RSpec.describe ImageUtil::Color do
     overlay = ImageUtil::Color[255, 0, 0, 0.5]
     (base + overlay).should == ImageUtil::Color.new(127.5, 0, 127.5, 255)
   end
+
+  it 'multiplies alpha with *' do
+    (ImageUtil::Color[1, 2, 3, 128] * 0.5).should == ImageUtil::Color[1, 2, 3, 64]
+  end
 end


### PR DESCRIPTION
## Summary
- allow multiplying color alpha by a numeric factor
- test multiplying alpha with `*`

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_687d05a54480832a9a781e56fb89da01