### PR TITLE
Implement lazy codec registry

### DIFF
--- a/lib/image_util/codec/image_magick.rb
+++ b/lib/image_util/codec/image_magick.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ImageUtil
   module Codec
     module ImageMagick
@@ -19,7 +21,11 @@ module ImageUtil
         SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
       end
 
-      def encode(_format, image)
+      def encode(format, image)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
+
         IO.popen("magick pam:- sixel:-", "r+") do |io|
           io << Codec::Pam.encode(:pam, image, fill_to: 6)
           io.close_write
@@ -38,8 +44,6 @@ module ImageUtil
       def decode_io(*)
         raise UnsupportedFormatError, "decode not supported for sixel"
       end
-
-      Codec.register(:sixel, self)
     end
   end
 end

--- a/lib/image_util/codec/libpng.rb
+++ b/lib/image_util/codec/libpng.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module ImageUtil
   module Codec
+    # rubocop:disable Metrics/ModuleLength
     module Libpng
       SUPPORTED_FORMATS = [:png].freeze
 
@@ -58,7 +61,10 @@ module ImageUtil
         SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
       end
 
-      def encode(_format, image)
+      def encode(format, image)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
         raise UnsupportedFormatError, "libpng not available" unless AVAILABLE
 
         unless image.is_a?(Image)
@@ -108,7 +114,10 @@ module ImageUtil
         io << encode(format, image)
       end
 
-      def decode(_format, data)
+      def decode(format, data)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
         raise UnsupportedFormatError, "libpng not available" unless AVAILABLE
 
         img = PngImage.new
@@ -136,8 +145,7 @@ module ImageUtil
       def decode_io(format, io)
         decode(format, io.read)
       end
-
-      Codec.register(:png, self)
     end
+    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/image_util/codec/libturbojpeg.rb
+++ b/lib/image_util/codec/libturbojpeg.rb
@@ -4,7 +4,7 @@ module ImageUtil
   module Codec
     # rubocop:disable Metrics/ModuleLength
     module Libturbojpeg
-      SUPPORTED_FORMATS = %i[jpeg jpg].freeze
+      SUPPORTED_FORMATS = [:jpeg].freeze
 
       begin
         require "ffi"
@@ -61,7 +61,10 @@ module ImageUtil
         SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
       end
 
-      def encode(_format, image, quality: 75)
+      def encode(format, image, quality: 75)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
         raise UnsupportedFormatError, "libturbojpeg not available" unless AVAILABLE
 
         unless image.is_a?(Image)
@@ -101,7 +104,10 @@ module ImageUtil
         io << encode(format, image, **kwargs)
       end
 
-      def decode(_format, data)
+      def decode(format, data)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
         raise UnsupportedFormatError, "libturbojpeg not available" unless AVAILABLE
 
         handle = tjInitDecompress
@@ -140,9 +146,6 @@ module ImageUtil
       def decode_io(format, io)
         decode(format, io.read)
       end
-
-      Codec.register(:jpeg, self)
-      Codec.register(:jpg, self)
     end
     # rubocop:enable Metrics/ModuleLength
   end

--- a/lib/image_util/codec/pam.rb
+++ b/lib/image_util/codec/pam.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringio"
 
 module ImageUtil
@@ -13,7 +15,10 @@ module ImageUtil
         SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
       end
 
-      def encode(_format, image, fill_to: nil)
+      def encode(format, image, fill_to: nil)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
         unless image.dimensions.length <= 2
           raise ArgumentError, "can't convert to PAM more than 2 dimensions"
         end
@@ -49,10 +54,18 @@ module ImageUtil
       end
 
       def decode(format, data)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
+
         decode_io(format, StringIO.new(data))
       end
 
-      def decode_io(_format, io)
+      def decode_io(format, io)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
+
         header = {}
         while (line = io.gets)
           line = line.chomp
@@ -71,8 +84,6 @@ module ImageUtil
         buf = Image::Buffer.new([width, height], color_bits, depth, io_buf)
         Image.from_buffer(buf)
       end
-
-      Codec.register(:pam, self)
     end
   end
 end

--- a/lib/image_util/codec/ruby_sixel.rb
+++ b/lib/image_util/codec/ruby_sixel.rb
@@ -13,7 +13,10 @@ module ImageUtil
         SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
       end
 
-      def encode(_format, image)
+      def encode(format, image)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
         unless image.dimensions.length == 2
           raise ArgumentError, "only 2D images supported"
         end
@@ -87,9 +90,6 @@ module ImageUtil
       def decode_io(*)
         raise UnsupportedFormatError, "decode not supported for sixel"
       end
-
-      Codec.register(:ruby_sixel, self)
-      Codec.register(:sixel, self) unless ImageMagick.supported?(:sixel)
     end
   end
 end


### PR DESCRIPTION
## Summary
- redesign codec registry with lazy loading
- add registration declarations in `Codec`
- enforce format checks in each codec
- drop unused aliases (:jpg, :ruby_sixel)
- ensure magic comments and style compliance

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_687d05b5df34832a8067602cd9b951a8