### PR TITLE
Add PPM codec and background filter

### DIFF
--- a/lib/image_util/codec.rb
+++ b/lib/image_util/codec.rb
@@ -81,10 +81,12 @@ module ImageUtil
     autoload :Libpng, "image_util/codec/libpng"
     autoload :Libturbojpeg, "image_util/codec/libturbojpeg"
     autoload :Pam, "image_util/codec/pam"
+    autoload :Ppm, "image_util/codec/ppm"
     autoload :ImageMagick, "image_util/codec/image_magick"
     autoload :RubySixel, "image_util/codec/ruby_sixel"
 
     register_codec :Pam, :pam
+    register_codec :Ppm, :ppm
     register_codec :Libpng, :png
     register_codec :Libturbojpeg, :jpeg
     register_encoder :ImageMagick, :sixel

--- a/lib/image_util/codec/ppm.rb
+++ b/lib/image_util/codec/ppm.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module ImageUtil
+  module Codec
+    module Ppm
+      SUPPORTED_FORMATS = [:ppm].freeze
+
+      module_function
+
+      def supported?(format = nil)
+        return true if format.nil?
+
+        SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+      end
+
+      def encode(format, image, background: Color[:black])
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
+
+        unless image.dimensions.length == 2
+          raise ArgumentError, "only 2D images supported"
+        end
+
+        unless image.color_bits == 8
+          raise ArgumentError, "only 8-bit colors supported"
+        end
+
+        unless [3, 4].include?(image.color_length)
+          raise ArgumentError, "only RGB/RGBA images supported"
+        end
+
+        img = image.background(background)
+
+        width = img.width || 1
+        height = img.height || 1
+        header = "P6\n#{width} #{height}\n255\n".b
+
+        raw = img.buffer.get_string
+        if img.color_length == 4
+          data = "".b
+          pixel_bytes = 4
+          total = width * height
+          total.times do |i|
+            offset = i * pixel_bytes
+            data << raw.getbyte(offset).chr
+            data << raw.getbyte(offset + 1).chr
+            data << raw.getbyte(offset + 2).chr
+          end
+        else
+          data = raw
+        end
+
+        header + data
+      end
+
+      def encode_io(format, image, io, **kwargs)
+        io << encode(format, image, **kwargs)
+      end
+
+      def decode(format, data)
+        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+          raise UnsupportedFormatError, "unsupported format #{format}"
+        end
+
+        io = StringIO.new(data)
+        magic = io.gets&.chomp
+        raise ArgumentError, "bad magic" unless magic == "P6"
+
+        tokens = []
+        until tokens.length >= 3
+          line = io.gets
+          raise ArgumentError, "truncated header" unless line
+
+          line = line.sub(/#.*/, "").strip
+          next if line.empty?
+
+          tokens.concat(line.split)
+        end
+        width = tokens[0].to_i
+        height = tokens[1].to_i
+        maxval = tokens[2].to_i
+        raise ArgumentError, "only 8-bit colors supported" unless maxval == 255
+
+        raw = io.read
+        buf = IO::Buffer.for(raw)
+        image_buf = Image::Buffer.new([width, height], 8, 3, buf)
+        Image.from_buffer(image_buf)
+      end
+
+      def decode_io(format, io, **kwargs)
+        decode(format, io.read, **kwargs)
+      end
+    end
+  end
+end

--- a/lib/image_util/filter.rb
+++ b/lib/image_util/filter.rb
@@ -3,5 +3,6 @@
 module ImageUtil
   module Filter
     autoload :Dither, "image_util/filter/dither"
+    autoload :Background, "image_util/filter/background"
   end
 end

--- a/lib/image_util/filter/background.rb
+++ b/lib/image_util/filter/background.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ImageUtil
+  module Filter
+    module Background
+      def background!(color = Color[:black])
+        each_pixel_location do |loc|
+          self[*loc] = Color[color] + self[*loc]
+        end
+        self
+      end
+
+      def background(color = Color[:black]) = dup.tap { |i| i.background!(color) }
+    end
+  end
+end

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -137,6 +137,7 @@ module ImageUtil
     end
     include Enumerable
     include Filter::Dither
+    include Filter::Background
 
     def length = dimensions.last
 

--- a/spec/codec/codec_spec.rb
+++ b/spec/codec/codec_spec.rb
@@ -1,7 +1,53 @@
 require 'spec_helper'
 
+module ImageUtil
+  module Codec
+    module ParamTest
+      SUPPORTED_FORMATS = [:param].freeze
+
+      def self.supported?(_format = nil) = true
+
+      def self.encode(_format, _image, **kwargs)
+        @encode = kwargs
+        'ok'
+      end
+
+      def self.decode(_format, _data, **kwargs)
+        @decode = kwargs
+        ImageUtil::Image.new(1,1)
+      end
+
+      def self.encode_io(_format, _image, io, **kwargs)
+        @encode_io = kwargs
+        io << 'x'
+      end
+
+      def self.decode_io(_format, _io, **kwargs)
+        @decode_io = kwargs
+        ImageUtil::Image.new(1,1)
+      end
+    end
+  end
+end
+
 RSpec.describe ImageUtil::Codec do
   it 'raises UnsupportedFormatError for unknown format' do
     -> { ImageUtil::Codec.encode(:foo, ImageUtil::Image.new(1,1)) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
+  end
+
+  it 'passes parameters to codec methods' do
+    ImageUtil::Codec.register_codec :ParamTest, :param
+
+    img = ImageUtil::Image.new(1,1)
+    io = StringIO.new
+    ImageUtil::Codec.encode(:param, img, foo: 1)
+    ImageUtil::Codec.decode(:param, 'data', bar: 2)
+    ImageUtil::Codec.encode_io(:param, img, io, baz: 3)
+    ImageUtil::Codec.decode_io(:param, StringIO.new('x'), qux: 4)
+
+    ImageUtil::Codec::ParamTest.instance_variable_get(:@encode).should == { foo: 1 }
+    ImageUtil::Codec::ParamTest.instance_variable_get(:@decode).should == { bar: 2 }
+    ImageUtil::Codec::ParamTest.instance_variable_get(:@encode_io).should == { baz: 3 }
+    ImageUtil::Codec::ParamTest.instance_variable_get(:@decode_io).should == { qux: 4 }
   end
 end

--- a/spec/codec/ppm_spec.rb
+++ b/spec/codec/ppm_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Codec::Ppm do
+  it 'encodes and decodes a PPM image' do
+    img = ImageUtil::Image.new(2, 1) { |x, _| ImageUtil::Color[x*100, 0, 0] }
+    data = described_class.encode(:ppm, img)
+    data.start_with?("P6\n2 1\n255\n").should be true
+
+    decoded = described_class.decode(:ppm, data)
+    decoded.dimensions.should == [2, 1]
+    decoded[1, 0].should == ImageUtil::Color[100, 0, 0]
+  end
+
+  it 'applies background color' do
+    img = ImageUtil::Image.new(1,1) { ImageUtil::Color[0,0,255,128] }
+    data = described_class.encode(:ppm, img, background: ImageUtil::Color[255,0,0])
+    decoded = described_class.decode(:ppm, data)
+    decoded[0,0].r.should be_between(127,128)
+    decoded[0,0].b.should be_between(127,128)
+  end
+end

--- a/spec/filter/background_spec.rb
+++ b/spec/filter/background_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Image do
+  describe '#background!' do
+    it 'applies background color in place' do
+      img = described_class.new(1, 1) { ImageUtil::Color[0, 0, 0, 0] }
+      img.background!(ImageUtil::Color[10, 10, 10])
+      img[0,0].should == ImageUtil::Color[10,10,10]
+    end
+  end
+
+  describe '#background' do
+    it 'returns new image with background applied' do
+      img = described_class.new(1, 1) { ImageUtil::Color[0, 0, 0, 0] }
+      dup = img.background(ImageUtil::Color[20, 0, 0])
+      dup.should_not equal(img)
+      dup[0,0].should == ImageUtil::Color[20,0,0]
+      img[0,0].should == ImageUtil::Color[0,0,0,0]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- implement `Filter::Background` to overlay a color behind images
- add binary PPM codec using the background filter
- autoload the new filter and codec and register the codec
- include the background filter in `Image`
- test background filter, PPM codec, and kwargs forwarding

## Testing
- `bundle exec rubocop`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_687d0b5d9160832a9a136d6399afa51e