### PR TITLE
Refactor codec guards

### DIFF
--- a/lib/image_util/codec.rb
+++ b/lib/image_util/codec.rb
@@ -83,6 +83,7 @@ module ImageUtil
     autoload :Pam, "image_util/codec/pam"
     autoload :ImageMagick, "image_util/codec/image_magick"
     autoload :RubySixel, "image_util/codec/ruby_sixel"
+    autoload :Guard, "image_util/codec/guard"
 
     register_codec :Pam, :pam
     register_codec :Libpng, :png

--- a/lib/image_util/codec/guard.rb
+++ b/lib/image_util/codec/guard.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ImageUtil
+  module Codec
+    module Guard
+      def guard_supported_format!(format, supported)
+        return if supported.map { |f| f.to_s.downcase.to_sym }.include?(format.to_s.downcase.to_sym)
+
+        raise UnsupportedFormatError, "unsupported format #{format}"
+      end
+
+      def guard_image_class!(image)
+        return if image.is_a?(Image)
+
+        raise ArgumentError, "image must be an ImageUtil::Image"
+      end
+
+      def guard_2d_image!(image)
+        guard_image_class!(image)
+        return if image.dimensions.length == 2
+
+        raise ArgumentError, "only 2D images supported"
+      end
+
+      def guard_8bit_colors!(image)
+        guard_image_class!(image)
+        return if image.color_bits == 8
+
+        raise ArgumentError, "only 8-bit colors supported"
+      end
+
+      module_function :guard_supported_format!, :guard_image_class!, :guard_2d_image!, :guard_8bit_colors!
+    end
+  end
+end

--- a/lib/image_util/codec/image_magick.rb
+++ b/lib/image_util/codec/image_magick.rb
@@ -5,6 +5,8 @@ module ImageUtil
     module ImageMagick
       SUPPORTED_FORMATS = [:sixel].freeze
 
+      extend Guard
+
       module_function
 
       def magick_available?
@@ -22,9 +24,7 @@ module ImageUtil
       end
 
       def encode(format, image)
-        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
-          raise UnsupportedFormatError, "unsupported format #{format}"
-        end
+        guard_supported_format!(format, SUPPORTED_FORMATS)
 
         IO.popen("magick pam:- sixel:-", "r+") do |io|
           io << Codec::Pam.encode(:pam, image, fill_to: 6)

--- a/lib/image_util/codec/libpng.rb
+++ b/lib/image_util/codec/libpng.rb
@@ -2,9 +2,10 @@
 
 module ImageUtil
   module Codec
-    # rubocop:disable Metrics/ModuleLength
     module Libpng
       SUPPORTED_FORMATS = [:png].freeze
+
+      extend Guard
 
       begin
         require "ffi"
@@ -62,22 +63,11 @@ module ImageUtil
       end
 
       def encode(format, image)
-        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
-          raise UnsupportedFormatError, "unsupported format #{format}"
-        end
+        guard_supported_format!(format, SUPPORTED_FORMATS)
         raise UnsupportedFormatError, "libpng not available" unless AVAILABLE
 
-        unless image.is_a?(Image)
-          raise ArgumentError, "image must be an ImageUtil::Image"
-        end
-
-        unless image.dimensions.length == 2
-          raise ArgumentError, "only 2D images supported"
-        end
-
-        unless image.color_bits == 8
-          raise ArgumentError, "only 8-bit colors supported"
-        end
+        guard_2d_image!(image)
+        guard_8bit_colors!(image)
 
         fmt = if image.color_length == 4
                 PNG_FORMAT_RGBA
@@ -115,9 +105,7 @@ module ImageUtil
       end
 
       def decode(format, data)
-        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
-          raise UnsupportedFormatError, "unsupported format #{format}"
-        end
+        guard_supported_format!(format, SUPPORTED_FORMATS)
         raise UnsupportedFormatError, "libpng not available" unless AVAILABLE
 
         img = PngImage.new
@@ -146,6 +134,5 @@ module ImageUtil
         decode(format, io.read)
       end
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/image_util/codec/libturbojpeg.rb
+++ b/lib/image_util/codec/libturbojpeg.rb
@@ -6,6 +6,8 @@ module ImageUtil
     module Libturbojpeg
       SUPPORTED_FORMATS = [:jpeg].freeze
 
+      extend Guard
+
       begin
         require "ffi"
 
@@ -62,22 +64,11 @@ module ImageUtil
       end
 
       def encode(format, image, quality: 75)
-        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
-          raise UnsupportedFormatError, "unsupported format #{format}"
-        end
+        guard_supported_format!(format, SUPPORTED_FORMATS)
         raise UnsupportedFormatError, "libturbojpeg not available" unless AVAILABLE
 
-        unless image.is_a?(Image)
-          raise ArgumentError, "image must be an ImageUtil::Image"
-        end
-
-        unless image.dimensions.length == 2
-          raise ArgumentError, "only 2D images supported"
-        end
-
-        unless image.color_bits == 8
-          raise ArgumentError, "only 8-bit colors supported"
-        end
+        guard_2d_image!(image)
+        guard_8bit_colors!(image)
 
         fmt = image.color_length == 4 ? TJPF_RGBA : TJPF_RGB
 
@@ -105,9 +96,7 @@ module ImageUtil
       end
 
       def decode(format, data)
-        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
-          raise UnsupportedFormatError, "unsupported format #{format}"
-        end
+        guard_supported_format!(format, SUPPORTED_FORMATS)
         raise UnsupportedFormatError, "libturbojpeg not available" unless AVAILABLE
 
         handle = tjInitDecompress

--- a/lib/image_util/codec/pam.rb
+++ b/lib/image_util/codec/pam.rb
@@ -7,6 +7,8 @@ module ImageUtil
     module Pam
       SUPPORTED_FORMATS = [:pam].freeze
 
+      extend Guard
+
       module_function
 
       def supported?(format = nil)
@@ -16,9 +18,7 @@ module ImageUtil
       end
 
       def encode(format, image, fill_to: nil)
-        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
-          raise UnsupportedFormatError, "unsupported format #{format}"
-        end
+        guard_supported_format!(format, SUPPORTED_FORMATS)
         unless image.dimensions.length <= 2
           raise ArgumentError, "can't convert to PAM more than 2 dimensions"
         end
@@ -54,17 +54,13 @@ module ImageUtil
       end
 
       def decode(format, data)
-        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
-          raise UnsupportedFormatError, "unsupported format #{format}"
-        end
+        guard_supported_format!(format, SUPPORTED_FORMATS)
 
         decode_io(format, StringIO.new(data))
       end
 
       def decode_io(format, io)
-        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
-          raise UnsupportedFormatError, "unsupported format #{format}"
-        end
+        guard_supported_format!(format, SUPPORTED_FORMATS)
 
         header = {}
         while (line = io.gets)

--- a/lib/image_util/codec/ruby_sixel.rb
+++ b/lib/image_util/codec/ruby_sixel.rb
@@ -5,6 +5,8 @@ module ImageUtil
     module RubySixel
       SUPPORTED_FORMATS = [:sixel].freeze
 
+      extend Guard
+
       module_function
 
       def supported?(format = nil)
@@ -14,16 +16,9 @@ module ImageUtil
       end
 
       def encode(format, image)
-        unless SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
-          raise UnsupportedFormatError, "unsupported format #{format}"
-        end
-        unless image.dimensions.length == 2
-          raise ArgumentError, "only 2D images supported"
-        end
-
-        unless image.color_bits == 8
-          raise ArgumentError, "only 8-bit colors supported"
-        end
+        guard_supported_format!(format, SUPPORTED_FORMATS)
+        guard_2d_image!(image)
+        guard_8bit_colors!(image)
 
         img = if image.unique_color_count <= 256
                 image


### PR DESCRIPTION
## Summary
- add `Guard` mixin with guard helper methods
- autoload `Guard` and use in codecs
- simplify codec guard checks using mixin

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_687db2d19984832abf2545bd47f7d87f