### PR TITLE
Refactor specs for Statistic::Color

### DIFF
--- a/spec/filter/dither_spec.rb
+++ b/spec/filter/dither_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe ImageUtil::Image do
     it 'reduces colors in place' do
       img = described_class.new(4,1) { |x,_| ImageUtil::Color[x*50,0,0] }
       img.dither!(2)
-      colors = []
-      img.each_pixel { |c| colors << c.to_a }
-      colors.uniq.length.should <= 2
+      img.unique_color_count.should <= 2
     end
   end
 
@@ -16,12 +14,8 @@ RSpec.describe ImageUtil::Image do
       img = described_class.new(2,1) { |x,_| ImageUtil::Color[x*100,0,0] }
       dup = img.dither(1)
       dup.should_not equal(img)
-      orig_colors = []
-      img.each_pixel { |c| orig_colors << c.to_a }
-      new_colors = []
-      dup.each_pixel { |c| new_colors << c.to_a }
-      orig_colors.uniq.length.should == 2
-      new_colors.uniq.length.should == 1
+      img.unique_color_count.should == 2
+      dup.unique_color_count.should == 1
     end
   end
 end

--- a/spec/statistic/color_spec.rb
+++ b/spec/statistic/color_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Statistic::Color do
+  let(:image) do
+    ImageUtil::Image.new(2, 1) { |x, _y| ImageUtil::Color[x, 0, 0] }
+  end
+
+  it 'builds a histogram of pixel colors' do
+    image.histogram.should == {
+      ImageUtil::Color[0, 0, 0, 255] => 1,
+      ImageUtil::Color[1, 0, 0, 255] => 1
+    }
+  end
+
+  it 'returns unique colors' do
+    image.unique_colors.should match_array([
+      ImageUtil::Color[0, 0, 0, 255],
+      ImageUtil::Color[1, 0, 0, 255]
+    ])
+  end
+
+  it 'counts unique colors' do
+    image.unique_color_count.should == 2
+  end
+end


### PR DESCRIPTION
## Summary
- replace manual unique color checks in dither specs with `unique_color_count`
- add specs for `Statistic::Color` histogram helpers

## Testing
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_687db5a7bf28832aad57ae5e67a344c8