### PR TITLE
Add convenience image I/O helpers

### DIFF
--- a/lib/image_util/codec.rb
+++ b/lib/image_util/codec.rb
@@ -62,15 +62,17 @@ module ImageUtil
       def find_codec(list, format, preferred = nil)
         fmt = format.to_s.downcase
         if preferred
-          list.each do |r|
-            next unless r[:formats].include?(fmt) && r[:codec].to_s == preferred.to_s
+          r = list.find { |e| e[:formats].include?(fmt) && e[:codec].to_s == preferred.to_s }
+          raise UnsupportedFormatError, "unsupported format #{format}" unless r
 
-            codec = const_get(r[:codec])
-            return codec if !codec.respond_to?(:supported?) || codec.supported?(fmt.to_sym)
-
+          codec = const_get(r[:codec])
+          unless !codec.respond_to?(:supported?) || codec.supported?(fmt.to_sym)
             raise UnsupportedFormatError, "unsupported format #{format}"
           end
+
+          return codec
         end
+
         list.each do |r|
           next unless r[:formats].include?(fmt)
 

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -25,11 +25,11 @@ module ImageUtil
       allocate.tap { |i| i.initialize_from_buffer(...) }
     end
 
-    def self.from_string(data, format:, codec: nil, **kwargs)
+    def self.from_string(data, format, codec: nil, **kwargs)
       Codec.decode(format, data, codec: codec, **kwargs)
     end
 
-    def self.from_file(path_or_io, format:, codec: nil, **kwargs)
+    def self.from_file(path_or_io, format, codec: nil, **kwargs)
       if path_or_io.respond_to?(:read)
         Codec.decode_io(format, path_or_io, codec: codec, **kwargs)
       else
@@ -163,11 +163,11 @@ module ImageUtil
       Codec.encode(:pam, self, fill_to: fill_to)
     end
 
-    def to_string(format:, codec: nil, **kwargs)
+    def to_string(format, codec: nil, **kwargs)
       Codec.encode(format, self, codec: codec, **kwargs)
     end
 
-    def to_file(path_or_io, format:, codec: nil, **kwargs)
+    def to_file(path_or_io, format, codec: nil, **kwargs)
       if path_or_io.respond_to?(:write)
         Codec.encode_io(format, self, path_or_io, codec: codec, **kwargs)
       else

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -25,6 +25,20 @@ module ImageUtil
       allocate.tap { |i| i.initialize_from_buffer(...) }
     end
 
+    def self.from_string(data, format:, codec: nil, **kwargs)
+      Codec.decode(format, data, codec: codec, **kwargs)
+    end
+
+    def self.from_file(path_or_io, format:, codec: nil, **kwargs)
+      if path_or_io.respond_to?(:read)
+        Codec.decode_io(format, path_or_io, codec: codec, **kwargs)
+      else
+        File.open(path_or_io, "rb") do |io|
+          Codec.decode_io(format, io, codec: codec, **kwargs)
+        end
+      end
+    end
+
     def buffer = @buf
     def dimensions = @buf.dimensions
     def width = dimensions[0]
@@ -147,6 +161,20 @@ module ImageUtil
 
     def to_pam(fill_to: nil)
       Codec.encode(:pam, self, fill_to: fill_to)
+    end
+
+    def to_string(format:, codec: nil, **kwargs)
+      Codec.encode(format, self, codec: codec, **kwargs)
+    end
+
+    def to_file(path_or_io, format:, codec: nil, **kwargs)
+      if path_or_io.respond_to?(:write)
+        Codec.encode_io(format, self, path_or_io, codec: codec, **kwargs)
+      else
+        File.open(path_or_io, "wb") do |io|
+          Codec.encode_io(format, self, io, codec: codec, **kwargs)
+        end
+      end
     end
 
     def to_sixel

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -99,17 +99,17 @@ RSpec.describe ImageUtil::Image do
 
   it 'converts to string and back' do
     img = described_class.new(1,1) { ImageUtil::Color[1,2,3] }
-    str = img.to_string(format: :pam)
-    other = described_class.from_string(str, format: :pam)
+    str = img.to_string(:pam)
+    other = described_class.from_string(str, :pam)
     other[0,0].should == ImageUtil::Color[1,2,3,255]
   end
 
   it 'writes to and reads from files' do
     img = described_class.new(1,1) { ImageUtil::Color[4,5,6] }
     Tempfile.create('img') do |f|
-      img.to_file(f, format: :pam)
+      img.to_file(f, :pam)
       f.rewind
-      other = described_class.from_file(f, format: :pam)
+      other = described_class.from_file(f, :pam)
       other[0,0].should == ImageUtil::Color[4,5,6,255]
     end
   end
@@ -118,19 +118,19 @@ RSpec.describe ImageUtil::Image do
     img = described_class.new(1,1) { ImageUtil::Color[7,8,9] }
     Dir.mktmpdir do |dir|
       path = File.join(dir, 'tmp.pam')
-      img.to_file(path, format: :pam)
-      other = described_class.from_file(path, format: :pam)
+      img.to_file(path, :pam)
+      other = described_class.from_file(path, :pam)
       other[0,0].should == ImageUtil::Color[7,8,9,255]
     end
   end
 
   it 'respects preferred codec' do
     img = described_class.new(1,1)
-    img.to_string(format: :pam, codec: :Pam).lines.first.chomp.should == 'P7'
+    img.to_string(:pam, codec: :Pam).lines.first.chomp.should == 'P7'
   end
 
-  it 'falls back when preferred codec does not match' do
+  it 'raises when preferred codec is unsuitable' do
     img = described_class.new(1,1)
-    img.to_string(format: :pam, codec: :RubySixel).lines.first.chomp.should == 'P7'
+    -> { img.to_string(:pam, codec: :RubySixel) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
   end
 end

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'tempfile'
+require 'tmpdir'
 
 RSpec.describe ImageUtil::Image do
   it 'sets and gets pixel values' do
@@ -93,5 +95,42 @@ RSpec.describe ImageUtil::Image do
     img = described_class.new(1,1) { ImageUtil::Color[0] }
     pam = img.to_pam(fill_to: 6)
     pam.lines[2].should include('HEIGHT 6')
+  end
+
+  it 'converts to string and back' do
+    img = described_class.new(1,1) { ImageUtil::Color[1,2,3] }
+    str = img.to_string(format: :pam)
+    other = described_class.from_string(str, format: :pam)
+    other[0,0].should == ImageUtil::Color[1,2,3,255]
+  end
+
+  it 'writes to and reads from files' do
+    img = described_class.new(1,1) { ImageUtil::Color[4,5,6] }
+    Tempfile.create('img') do |f|
+      img.to_file(f, format: :pam)
+      f.rewind
+      other = described_class.from_file(f, format: :pam)
+      other[0,0].should == ImageUtil::Color[4,5,6,255]
+    end
+  end
+
+  it 'handles file paths' do
+    img = described_class.new(1,1) { ImageUtil::Color[7,8,9] }
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'tmp.pam')
+      img.to_file(path, format: :pam)
+      other = described_class.from_file(path, format: :pam)
+      other[0,0].should == ImageUtil::Color[7,8,9,255]
+    end
+  end
+
+  it 'respects preferred codec' do
+    img = described_class.new(1,1)
+    img.to_string(format: :pam, codec: :Pam).lines.first.chomp.should == 'P7'
+  end
+
+  it 'falls back when preferred codec does not match' do
+    img = described_class.new(1,1)
+    img.to_string(format: :pam, codec: :RubySixel).lines.first.chomp.should == 'P7'
   end
 end


### PR DESCRIPTION
## Summary
- extend Codec to allow choosing a preferred codec
- add Image.from_string and Image.from_file helpers
- add Image#to_string and Image#to_file helpers
- test image I/O helpers and preferred codec handling

## Testing
- `bundle exec rake spec`
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_687dc4fa977c832a8f1824778f0f7738