### PR TITLE
Fix stackprof on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,4 @@ gem "ffi", "~> 1.16"
 gem "pry", "~> 0.15.2"
 gem "simplecov", "~> 0.22"
 
-gem "stackprof", "~> 0.2.27"
+gem "stackprof", "~> 0.2.27" unless Gem.win_platform?


### PR DESCRIPTION
## Summary
- avoid enabling stackprof when running on Windows

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`


------
https://chatgpt.com/codex/tasks/task_e_687dca98db68832abece596289960828