### PR TITLE
Add Paste filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ i[0..1, 0..1] = ImageUtil::Color['#0000ff']
 i.each_pixel do |pixel|
   # pixel is an ImageUtil::Color instance
 end
+
+# paste one image into another
+target = ImageUtil::Image.new(8, 8) { ImageUtil::Color[0] }
+source = ImageUtil::Image.new(2, 2) { ImageUtil::Color[255, 0, 0, 128] }
+target.paste!(source, 3, 3, respect_alpha: true)
 ```
 
 ### Codecs

--- a/lib/image_util/filter.rb
+++ b/lib/image_util/filter.rb
@@ -4,6 +4,7 @@ module ImageUtil
   module Filter
     autoload :Dither, "image_util/filter/dither"
     autoload :Background, "image_util/filter/background"
+    autoload :Paste, "image_util/filter/paste"
 
     autoload :Mixin, "image_util/filter/_mixin"
   end

--- a/lib/image_util/filter/paste.rb
+++ b/lib/image_util/filter/paste.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ImageUtil
+  module Filter
+    module Paste
+      extend ImageUtil::Filter::Mixin
+
+      def paste!(image, *location, respect_alpha: false)
+        raise TypeError, "image must be an Image" unless image.is_a?(Image)
+
+        image.each_pixel_location do |loc|
+          dest = location.zip(loc).map { |a, b| a + b }
+          begin
+            if respect_alpha
+              self[*dest] += image[*loc]
+            else
+              self[*dest] = image[*loc]
+            end
+          rescue IndexError
+            # ignore pixels outside bounds
+          end
+        end
+
+        self
+      end
+
+      define_immutable_version :paste
+    end
+  end
+end

--- a/lib/image_util/filter/paste.rb
+++ b/lib/image_util/filter/paste.rb
@@ -8,16 +8,22 @@ module ImageUtil
       def paste!(image, *location, respect_alpha: false)
         raise TypeError, "image must be an Image" unless image.is_a?(Image)
 
-        image.each_pixel_location do |loc|
-          dest = location.zip(loc).map { |a, b| a + b }
+        last_dim = image.dimensions.length - 1
+
+        image.each_with_index do |val, idx|
+          new_loc = location.dup
+          new_loc[last_dim] += idx
+
           begin
-            if respect_alpha
-              self[*dest] += image[*loc]
+            if val.is_a?(Image)
+              paste!(val, *new_loc, respect_alpha: respect_alpha)
+            elsif respect_alpha
+              self[*new_loc] += val
             else
-              self[*dest] = image[*loc]
+              self[*new_loc] = val
             end
           rescue IndexError
-            # ignore pixels outside bounds
+            # do nothing, image overlaps
           end
         end
 

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -108,14 +108,7 @@ module ImageUtil
       if location.all?(Numeric)
         case value
         when Image
-          last_dim = value.dimensions.length - 1
-          value.each_with_index do |i, idx|
-            new_location = location.dup
-            new_location[last_dim] += idx
-            self[*new_location] = i
-          rescue IndexError
-            # do nothing, image overlaps
-          end
+          paste!(value, *location)
         else
           location = location.map(&:to_i)
           check_bounds!(location)

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -155,6 +155,7 @@ module ImageUtil
     include Enumerable
     include Filter::Dither
     include Filter::Background
+    include Filter::Paste
     include Statistic::Color
 
     def length = dimensions.last

--- a/spec/filter/paste_spec.rb
+++ b/spec/filter/paste_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Image do
+  describe '#paste!' do
+    it 'copies another image in place' do
+      base = described_class.new(3, 3) { ImageUtil::Color[0] }
+      other = described_class.new(2, 2) { |x, y| ImageUtil::Color[x + y] }
+      base.paste!(other, 1, 1)
+      base[1,1].should == ImageUtil::Color[0]
+      base[2,2].should == ImageUtil::Color[2]
+    end
+
+    it 'respects alpha when requested' do
+      base = described_class.new(1, 1) { ImageUtil::Color[10, 10, 10] }
+      over = described_class.new(1, 1) { ImageUtil::Color[20, 0, 0, 128] }
+      base.paste!(over, 0, 0, respect_alpha: true)
+      expected = ImageUtil::Color[10, 10, 10] + ImageUtil::Color[20,0,0,128]
+      expected = ImageUtil::Color.new(*expected.map(&:to_i))
+      base[0,0].should == expected
+    end
+  end
+
+  describe '#paste' do
+    it 'returns new image without modifying original' do
+      base = described_class.new(2, 1) { ImageUtil::Color[0] }
+      other = described_class.new(1, 1) { ImageUtil::Color[1] }
+      dup = base.paste(other, 1, 0)
+      dup.should_not equal(base)
+      dup[1,0].should == ImageUtil::Color[1]
+      base[1,0].should == ImageUtil::Color[0]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- isolate image copying logic into a new `Paste` filter
- include the new filter in the Image class
- test pasting behaviour including optional alpha blending

## Testing
- `bundle exec rspec`
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_687dd561a694832a8eeb3ad3aa80df3c