### PR TITLE
Implement fast 1D paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Native SIXEL encoder
 - Install libjpeg-turbo on Linux in CI
 - Background filter
+- Faster 1D paste using direct buffer copy
 
 ## [0.1.0] - 2025-07-19
 

--- a/lib/image_util/filter/draw.rb
+++ b/lib/image_util/filter/draw.rb
@@ -5,6 +5,7 @@ module ImageUtil
     module Draw
       extend ImageUtil::Filter::Mixin
 
+      # rubocop:disable Metrics/ParameterLists
       def draw_2d_function!(
         color = Color[:black],
         limit = nil,
@@ -37,6 +38,7 @@ module ImageUtil
 
         self
       end
+      # rubocop:enable Metrics/ParameterLists
 
       def draw_segment!(begin_loc, end_loc, color = Color[:black], view: View::Subpixel)
         begin_x, begin_y = begin_loc

--- a/lib/image_util/filter/paste.rb
+++ b/lib/image_util/filter/paste.rb
@@ -8,6 +8,24 @@ module ImageUtil
       def paste!(image, *location, respect_alpha: false)
         raise TypeError, "image must be an Image" unless image.is_a?(Image)
 
+        if !respect_alpha &&
+           image.dimensions.length == 1 &&
+           image.color_bits == color_bits &&
+           image.color_length == color_length &&
+           buffer.respond_to?(:copy_1d)
+          loc = location.map(&:to_i)
+          begin
+            check_bounds!(loc)
+          rescue IndexError
+            return self
+          end
+
+          if loc.first + image.length <= width
+            buffer.copy_1d(image.buffer, *loc)
+            return self
+          end
+        end
+
         last_dim = image.dimensions.length - 1
 
         image.each_with_index do |val, idx|

--- a/lib/image_util/image/buffer.rb
+++ b/lib/image_util/image/buffer.rb
@@ -95,6 +95,16 @@ module ImageUtil
 
       def get_string = @buffer.get_string
 
+      def io_buffer = @buffer
+
+      def copy_1d(other, *location)
+        index = offset_of(*location)
+        length = [other.width, width - location.first].min
+        return if length <= 0
+
+        @buffer.copy(other.io_buffer, index, length * pixel_bytes)
+      end
+
       # Optimizations for most common usecases:
       def apply_singleton_optimizations!
         # rubocop:disable Style/GuardClause

--- a/spec/filter/paste_spec.rb
+++ b/spec/filter/paste_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe ImageUtil::Image do
       expected = ImageUtil::Color.new(*expected.map(&:to_i))
       base[0,0].should == expected
     end
+
+    it 'pastes a 1d image onto another image' do
+      base = described_class.new(3, 1) { ImageUtil::Color[0] }
+      line = described_class.new(2) { |loc| ImageUtil::Color[loc.first] }
+      base.paste!(line, 1, 0)
+      base[1,0].should == ImageUtil::Color[0]
+      base[2,0].should == ImageUtil::Color[1]
+    end
   end
 
   describe '#paste' do

--- a/spec/image/buffer_spec.rb
+++ b/spec/image/buffer_spec.rb
@@ -42,4 +42,14 @@ RSpec.describe ImageUtil::Image::Buffer do
     buf32.set([0,0], [1,2,3])
     buf32.get([0,0]).should == ImageUtil::Color[1,2,3]
   end
+
+  it 'copies a 1d buffer onto another buffer' do
+    dest = described_class.new([3, 1], 8, 3)
+    src = described_class.new([2], 8, 3)
+    src.set([0], [1, 2, 3])
+    src.set([1], [4, 5, 6])
+    dest.copy_1d(src, 1, 0)
+    dest.get([1, 0]).should == ImageUtil::Color[1, 2, 3]
+    dest.get([2, 0]).should == ImageUtil::Color[4, 5, 6]
+  end
 end


### PR DESCRIPTION
## Summary
- add `copy_1d` helper for fast buffer copies
- use `copy_1d` in `paste!` when possible
- silence RuboCop warning in Draw filter
- document the new optimisation
- test buffer copying and 1d pasting

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_687de8ebba58832a88d853bcdf747537