### PR TITLE
Fix line drawing slope

### DIFF
--- a/lib/image_util/filter/draw.rb
+++ b/lib/image_util/filter/draw.rb
@@ -51,13 +51,13 @@ module ImageUtil
           begin_x, end_x, begin_y, end_y = end_x, begin_x, end_y, begin_y if begin_y > end_y
           a = (end_x - begin_x).to_f / (end_y - begin_y)
           draw_function!(color, begin_y..end_y, axis: :y, view: view) do |y|
-            begin_x + y * a
+            begin_x + (y - begin_y) * a
           end
         else
           begin_x, end_x, begin_y, end_y = end_x, begin_x, end_y, begin_y if begin_x > end_x
           a = (end_y - begin_y).to_f / (end_x - begin_x)
           draw_function!(color, begin_x..end_x, axis: :x, view: view) do |x|
-            begin_y + x * a
+            begin_y + (x - begin_x) * a
           end
         end
       end

--- a/spec/filter/draw_spec.rb
+++ b/spec/filter/draw_spec.rb
@@ -17,5 +17,11 @@ RSpec.describe ImageUtil::Image do
       img.draw_line!([0,0], [2,2], ImageUtil::Color[2], view: ImageUtil::View::Rounded)
       img[1,1].should == ImageUtil::Color[2]
     end
+
+    it 'handles lines not starting at the origin' do
+      img = described_class.new(5,5) { ImageUtil::Color[0] }
+      img.draw_line!([3,2], [4,3], ImageUtil::Color[1], view: ImageUtil::View::Interpolated)
+      img[4,3].should == ImageUtil::Color[1]
+    end
   end
 end


### PR DESCRIPTION
## Summary
- correct slope calculation in `draw_line!`
- test lines that don't start at origin

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_687e004321c8832aa90f62f04c681aa5