### PR TITLE
Support image range assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Range assignments with images now resize the image before pasting
 
 ## [0.1.0] - 2025-07-21
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ img[2, 2] = :yellow
 img.to_file("pixel_patch.png", :png)
 ```
 
+Assigning an image to a range automatically resizes it to fit before pasting.
+
 Iteration helpers operate on arbitrary ranges and share the same syntax used
 when indexing images.  `each_pixel` yields color objects, while
 `each_pixel_location` yields coordinate arrays.  `set_each_pixel_by_location`

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -136,9 +136,11 @@ module ImageUtil
           @buf.set(location, value)
         end
       else
-        _, locations = location_expand(location)
-        locations.each do |loc|
-          self[*loc] = value
+        sizes, locations = location_expand(location)
+        if value.is_a?(Image)
+          paste!(value.resize(*sizes), *locations.first)
+        else
+          locations.each { |loc| self[*loc] = value }
         end
       end
     end

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe ImageUtil::Image do
     base[2,2].should == ImageUtil::Color[1]
   end
 
+  it 'resizes images when assigning to ranges' do
+    base = described_class.new(3,3) { ImageUtil::Color[0] }
+    other = described_class.new(1,1) { ImageUtil::Color[5] }
+    base[1..2, 1..2] = other
+    base[1,1].should == ImageUtil::Color[5]
+    base[2,2].should == ImageUtil::Color[5]
+  end
+
   it 'handles each_pixel_location' do
     img = described_class.new(2,2) { ImageUtil::Color[0] }
     locs = []


### PR DESCRIPTION
## Summary
- resize image values when assigning to range locations
- document automatic resize/paste in README
- note new feature in CHANGELOG
- test assigning an image to range coordinates

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_687e24fd0410832ab0b601c3cb78d647