### PR TITLE
Add ImageMagick codec features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,5 +7,6 @@
 - Use RSpec's `should` syntax instead of `expect`.
 - For one-line methods, use the `def name = expression` style.
 - After adding new features or modifying existing ones, change documentation accordingly (especially README and especially CHANGELOG).
+- Don't discuss codec internals or bug fixes in README. Only list supported formats. Document bug fixes in the CHANGELOG, not in README.
 - Specs target at least 80% coverage as enforced by SimpleCov.
 - The library aims to remain lightweight and portable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Support for all CSS color names
 - Range assignments with images now resize the image before pasting
 - Circle drawing filter
+- ImageMagick codec can encode and decode `png`, `jpeg` and `sixel`
+- Fixed ImageMagick codec API so `encode` and `decode` are primary methods
 
 ## [0.1.0] - 2025-07-21
 

--- a/lib/image_util/codec.rb
+++ b/lib/image_util/codec.rb
@@ -111,7 +111,7 @@ module ImageUtil
     register_codec :Libpng, :png
     register_codec :Libturbojpeg, :jpeg
     register_encoder :Libsixel, :sixel
-    register_encoder :ImageMagick, :sixel
+    register_codec :ImageMagick, :png, :jpeg, :sixel
     register_encoder :RubySixel, :sixel
   end
 end

--- a/spec/codec/image_magick_spec.rb
+++ b/spec/codec/image_magick_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Codec::ImageMagick do
+  let(:img) { ImageUtil::Image.new(1, 1) { ImageUtil::Color[255, 0, 0] } }
+  let(:pam) { ImageUtil::Codec::Pam.encode(:pam, img) }
+
+  before do
+    allow(described_class).to receive(:magick_available?).and_return(true)
+  end
+
+  it 'encodes using ImageMagick' do
+    proc_io = StringIO.new
+    def proc_io.close_write; end
+    def proc_io.read; 'OUT' end
+    allow(IO).to receive(:popen).and_yield(proc_io)
+
+    out = described_class.encode(:png, img)
+    out.should == 'OUT'
+    proc_io.string.bytes.should == pam.bytes
+  end
+
+  it 'encodes JPEG' do
+    proc_io = StringIO.new
+    def proc_io.close_write; end
+    def proc_io.read; 'JOUT' end
+    allow(IO).to receive(:popen).and_yield(proc_io)
+
+    out = described_class.encode(:jpeg, img)
+    out.should == 'JOUT'
+    proc_io.string.bytes.should == pam.bytes
+  end
+
+  it 'decodes using ImageMagick' do
+    proc_io = StringIO.new
+    def proc_io.close_write; end
+    pam_str = pam
+    proc_io.define_singleton_method(:read) { pam_str }
+    allow(IO).to receive(:popen).and_yield(proc_io)
+
+    decoded = described_class.decode(:png, 'PNG')
+    decoded.dimensions.should == [1, 1]
+    proc_io.string.should == 'PNG'
+  end
+
+  it 'decodes JPEG' do
+    proc_io = StringIO.new
+    def proc_io.close_write; end
+    pam_str = pam
+    proc_io.define_singleton_method(:read) { pam_str }
+    allow(IO).to receive(:popen).and_yield(proc_io)
+
+    decoded = described_class.decode(:jpeg, 'JPG')
+    decoded.dimensions.should == [1, 1]
+    proc_io.string.should == 'JPG'
+  end
+end


### PR DESCRIPTION
## Summary
- clarify docs: bug fixes belong in the CHANGELOG, not README
- restore ImageMagick encode/decode hierarchy with encode_io/decode_io wrappers
- update specs to call the primary methods
- document ImageMagick API fix in CHANGELOG

## Testing
- `bundle exec rake spec`


------
https://chatgpt.com/codex/tasks/task_e_687e3003aff8832a9d6975502c95acf3