### PR TITLE
Improve terminal support docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ img.to_file("out.png", :png)
 binary = img.to_string(:jpeg)
 ```
 
-## SIXEL Output
+## Terminal Output
 
 Images can be previewed in compatible terminals:
 
 ```ruby
-puts img.to_sixel
+puts ImageUtil::Terminal.output_image($stdin, $stdout, img)
 ```
 
 In `irb` or `pry` the `inspect` method shows the image automatically, so you can
@@ -51,7 +51,7 @@ just evaluate the object:
 img
 ```
 
-Most notably, SIXEL works in Windows Terminal, Konsole (KDE), iTerm2 (macOS), XTerm (launch with: `xterm -ti vt340`). Here's how it looks in Konsole:
+The library checks if the Kitty graphics protocol is available and falls back to SIXEL otherwise. Most notably, SIXEL works in Windows Terminal, Konsole (KDE), iTerm2 (macOS), XTerm (launch with: `xterm -ti vt340`). Here's how it looks in Konsole:
 
 ![Sixel example](docs/samples/sixel.png)
 

--- a/image_util.gemspec
+++ b/image_util.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ffi", "~> 1.16"
   spec.add_dependency "base64"
+  spec.add_dependency "ffi", "~> 1.16"
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"

--- a/spec/codec/kitty_spec.rb
+++ b/spec/codec/kitty_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Codec::Kitty do
+  it 'encodes an image to the kitty protocol' do
+    img = ImageUtil::Image.new(1, 1) { ImageUtil::Color[255, 0, 0] }
+    data = described_class.encode(:kitty, img)
+    data.start_with?("\e_G").should be true
+    data.end_with?("\e\\").should be true
+  end
+
+  it 'raises on bad input' do
+    img = ImageUtil::Image.new(1, 1, 1)
+    -> { described_class.encode(:kitty, img) }.should raise_error(ArgumentError)
+    img = ImageUtil::Image.new(1, 1, color_bits: 16)
+    -> { described_class.encode(:kitty, img) }.should raise_error(ArgumentError)
+    img = ImageUtil::Image.new(1, 1)
+    -> { described_class.encode(:foo, img) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
+  end
+
+  it 'does not support decoding' do
+    -> { described_class.decode(:kitty, '') }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
+    -> { described_class.decode_io(:kitty, StringIO.new) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
+  end
+end

--- a/spec/terminal_spec.rb
+++ b/spec/terminal_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Terminal do
+  let(:termin) { Object.new.tap { |o| def o.tty? = true } }
+  let(:termout) { Object.new.tap { |o| def o.tty? = true } }
+
+  describe '.detect_support' do
+    it 'returns empty array when not ttys' do
+      def termin.tty? = false
+      described_class.detect_support(termin, termout).should == []
+    end
+
+    it 'detects kitty support' do
+      allow(described_class).to receive(:query_terminal).and_return(true, false)
+      described_class.detect_support(termin, termout).should == %i[tty kitty]
+    end
+
+    it 'detects sixel support' do
+      allow(described_class).to receive(:query_terminal).and_return(false, true)
+      described_class.detect_support(termin, termout).should == %i[tty sixel]
+    end
+  end
+
+  describe '.output_image' do
+    it 'uses kitty when available' do
+      img = ImageUtil::Image.new(1, 1)
+      allow(described_class).to receive(:detect_support).and_return(%i[tty kitty])
+      img.should_receive(:to_string).with(:kitty).and_return('K')
+      described_class.output_image(termin, termout, img).should == 'K'
+    end
+
+    it 'uses sixel when kitty is not available' do
+      img = ImageUtil::Image.new(1, 1)
+      allow(described_class).to receive(:detect_support).and_return(%i[tty sixel])
+      img.should_receive(:to_string).with(:sixel).and_return('S')
+      described_class.output_image(termin, termout, img).should == 'S'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- document automatic terminal output detection
- re-order gemspec dependencies via rubocop
- test the Kitty codec and terminal helper

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`


------
https://chatgpt.com/codex/tasks/task_e_688122e8492c832a8dace75a67b768cf