### PR TITLE
Remove redundant IO helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Terminal detection for graphic protocols
 - Support Kitty graphics protocol
 - Rename `color_length` to a more appropriate name `channels`
+- Remove redundant `encode_io` and `decode_io` implementations
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/bin/rebuild-images-in-readme
+++ b/bin/rebuild-images-in-readme
@@ -18,5 +18,7 @@ template = Regexp.escape(template).gsub(/\\-\\-.*?\\-\\-/, "([^`]*?)")
 template = Regexp.new(template, "m")
 
 readme.scan(template) do |code,title,filename|
+  # rubocop:disable Security/Eval
   eval(code).to_file("docs/samples/#{filename}", :png)
+  # rubocop:enable Security/Eval
 end

--- a/lib/image_util/codec/image_magick.rb
+++ b/lib/image_util/codec/image_magick.rb
@@ -36,10 +36,6 @@ module ImageUtil
         end
       end
 
-      def encode_io(format, image, io)
-        io << encode(format, image)
-      end
-
       def decode(format, data)
         guard_supported_format!(format, SUPPORTED_FORMATS)
 
@@ -48,10 +44,6 @@ module ImageUtil
           proc_io.close_write
           Pam.decode(:pam, proc_io.read)
         end
-      end
-
-      def decode_io(format, io)
-        decode(format, io.read)
       end
     end
   end

--- a/lib/image_util/codec/kitty.rb
+++ b/lib/image_util/codec/kitty.rb
@@ -61,15 +61,7 @@ module ImageUtil
         out
       end
 
-      def encode_io(format, image, io)
-        io << encode(format, image)
-      end
-
       def decode(*)
-        raise UnsupportedFormatError, "decode not supported for sixel"
-      end
-
-      def decode_io(*)
         raise UnsupportedFormatError, "decode not supported for sixel"
       end
     end

--- a/lib/image_util/codec/libpng.rb
+++ b/lib/image_util/codec/libpng.rb
@@ -100,10 +100,6 @@ module ImageUtil
         png_image_free(img) if img
       end
 
-      def encode_io(format, image, io)
-        io << encode(format, image)
-      end
-
       def decode(format, data)
         guard_supported_format!(format, SUPPORTED_FORMATS)
         raise UnsupportedFormatError, "libpng not available" unless AVAILABLE
@@ -128,10 +124,6 @@ module ImageUtil
         Image.from_buffer(buf)
       ensure
         png_image_free(img) if img
-      end
-
-      def decode_io(format, io)
-        decode(format, io.read)
       end
     end
   end

--- a/lib/image_util/codec/libsixel.rb
+++ b/lib/image_util/codec/libsixel.rb
@@ -106,15 +106,7 @@ module ImageUtil
         sixel_output_unref(output) if defined?(output) && output && !output.null?
       end
 
-      def encode_io(format, image, io)
-        io << encode(format, image)
-      end
-
       def decode(*)
-        raise UnsupportedFormatError, "decode not supported for sixel"
-      end
-
-      def decode_io(*)
         raise UnsupportedFormatError, "decode not supported for sixel"
       end
     end

--- a/lib/image_util/codec/libturbojpeg.rb
+++ b/lib/image_util/codec/libturbojpeg.rb
@@ -2,7 +2,6 @@
 
 module ImageUtil
   module Codec
-    # rubocop:disable Metrics/ModuleLength
     module Libturbojpeg
       SUPPORTED_FORMATS = [:jpeg].freeze
 
@@ -91,10 +90,6 @@ module ImageUtil
         tjDestroy(handle) if handle && !handle.null?
       end
 
-      def encode_io(format, image, io, **kwargs)
-        io << encode(format, image, **kwargs)
-      end
-
       def decode(format, data)
         guard_supported_format!(format, SUPPORTED_FORMATS)
         raise UnsupportedFormatError, "libturbojpeg not available" unless AVAILABLE
@@ -131,11 +126,6 @@ module ImageUtil
       ensure
         tjDestroy(handle) if handle && !handle.null?
       end
-
-      def decode_io(format, io)
-        decode(format, io.read)
-      end
     end
-    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/image_util/codec/pam.rb
+++ b/lib/image_util/codec/pam.rb
@@ -49,10 +49,6 @@ module ImageUtil
         header + image.buffer.get_string + fill_buffer
       end
 
-      def encode_io(format, image, io, **kwargs)
-        io << encode(format, image, **kwargs)
-      end
-
       def decode(format, data)
         guard_supported_format!(format, SUPPORTED_FORMATS)
 

--- a/lib/image_util/codec/ruby_sixel.rb
+++ b/lib/image_util/codec/ruby_sixel.rb
@@ -100,15 +100,7 @@ module ImageUtil
         out
       end
 
-      def encode_io(format, image, io)
-        io << encode(format, image)
-      end
-
       def decode(*)
-        raise UnsupportedFormatError, "decode not supported for sixel"
-      end
-
-      def decode_io(*)
         raise UnsupportedFormatError, "decode not supported for sixel"
       end
     end

--- a/spec/codec/kitty_spec.rb
+++ b/spec/codec/kitty_spec.rb
@@ -19,6 +19,6 @@ RSpec.describe ImageUtil::Codec::Kitty do
 
   it 'does not support decoding' do
     -> { described_class.decode(:kitty, '') }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
-    -> { described_class.decode_io(:kitty, StringIO.new) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
+    -> { ImageUtil::Codec.decode_io(:kitty, StringIO.new, codec: described_class) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
   end
 end

--- a/spec/codec/ruby_sixel_spec.rb
+++ b/spec/codec/ruby_sixel_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ImageUtil::Codec::RubySixel do
 
   it 'does not support decoding' do
     ->{ described_class.decode(:sixel, '') }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
-    ->{ described_class.decode_io(:sixel, StringIO.new) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
+    -> { ImageUtil::Codec.decode_io(:sixel, StringIO.new, codec: described_class) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
   end
 
   it 'dithers images with many colors' do


### PR DESCRIPTION
## Summary
- remove trivial `encode_io` and `decode_io` implementations
- adjust specs to use Codec.decode_io for unsupported codecs
- document the change in CHANGELOG

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_68813ffeda8c832aab612ae40808eccc