### PR TITLE
Add ChunkyPNG fallback codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Terminal detection for graphic protocols
 - Support Kitty graphics protocol
 - Rename `color_length` to a more appropriate name `channels`
+- Fallback PNG codec via chunky_png
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.21"
 
+gem "chunky_png", "~> 1.4"
 gem "ffi", "~> 1.16"
 gem "pry", "~> 0.15.2"
 gem "simplecov", "~> 0.22"

--- a/lib/image_util/codec.rb
+++ b/lib/image_util/codec.rb
@@ -101,6 +101,7 @@ module ImageUtil
     autoload :Guard, "image_util/codec/_guard"
 
     autoload :Libpng, "image_util/codec/libpng"
+    autoload :ChunkyPng, "image_util/codec/chunky_png"
     autoload :Libturbojpeg, "image_util/codec/libturbojpeg"
     autoload :Pam, "image_util/codec/pam"
     autoload :Libsixel, "image_util/codec/libsixel"
@@ -111,6 +112,7 @@ module ImageUtil
     register_codec :Pam, :pam
     register_codec :Kitty, :kitty
     register_codec :Libpng, :png
+    register_codec :ChunkyPng, :png
     register_codec :Libturbojpeg, :jpeg
     register_encoder :Libsixel, :sixel
     register_codec :ImageMagick, :png, :jpeg, :sixel

--- a/lib/image_util/codec/chunky_png.rb
+++ b/lib/image_util/codec/chunky_png.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module ImageUtil
+  module Codec
+    module ChunkyPng
+      SUPPORTED_FORMATS = [:png].freeze
+
+      extend Guard
+
+      begin
+        require "chunky_png"
+        AVAILABLE = true
+      rescue LoadError
+        AVAILABLE = false
+      end
+
+      module_function
+
+      def supported?(format = nil)
+        return false unless AVAILABLE
+
+        return true if format.nil?
+
+        SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+      end
+
+      def encode(format, image)
+        guard_supported_format!(format, SUPPORTED_FORMATS)
+        raise UnsupportedFormatError, "chunky_png not available" unless AVAILABLE
+
+        guard_2d_image!(image)
+        guard_8bit_colors!(image)
+
+        raw = if image.channels == 4
+                image.buffer.get_string
+              else
+                data = String.new(capacity: image.width * image.height * 4)
+                buf = image.buffer
+                idx = 0
+                step = buf.pixel_bytes
+                image.height.times do
+                  image.width.times do
+                    color = buf.get_index(idx)
+                    data << color[0].chr << color[1].chr << color[2].chr << 255.chr
+                    idx += step
+                  end
+                end
+                data
+              end
+
+        png = ::ChunkyPNG::Image.from_rgba_stream(image.width, image.height, raw)
+        png.to_blob
+      end
+
+      def decode(format, data)
+        guard_supported_format!(format, SUPPORTED_FORMATS)
+        raise UnsupportedFormatError, "chunky_png not available" unless AVAILABLE
+
+        png = ::ChunkyPNG::Image.from_blob(data)
+        raw = png.to_rgba_stream
+        io_buf = IO::Buffer.for(raw)
+        buf = Image::Buffer.new([png.width, png.height], 8, 4, io_buf)
+        Image.from_buffer(buf)
+      end
+    end
+  end
+end

--- a/spec/codec/chunky_png_spec.rb
+++ b/spec/codec/chunky_png_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Codec::ChunkyPng do
+  before do
+    skip 'chunky_png not available' unless described_class.supported?
+  end
+
+  it 'encodes and decodes a PNG image' do
+    img = ImageUtil::Image.new(2, 1) { |x, _y| ImageUtil::Color[x, 0, 0] }
+    data = described_class.encode(:png, img)
+    data.start_with?("\x89PNG\r\n\x1a\n".b).should be true
+
+    decoded = described_class.decode(:png, data)
+    decoded.dimensions.should == [2, 1]
+    decoded[1, 0].should == ImageUtil::Color[1, 0, 0]
+  end
+
+  it 'raises for unsupported color depth' do
+    img = ImageUtil::Image.new(1, 1, color_bits: 16)
+    -> { described_class.encode(:png, img) }.should raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
## Summary
- support PNG encoding/decoding without libpng by adding a ChunkyPNG codec
- hook ChunkyPNG codec into the codec registry
- document the new fallback in CHANGELOG
- include chunky_png gem in development Gemfile
- test ChunkyPNG codec

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`


------
https://chatgpt.com/codex/tasks/task_e_6881431eb8a0832a9a002c55a73d9f76