### PR TITLE
Add redimension filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Rename `#set_each_pixel_by_location` to `#set_each_pixel_by_location!` since it's mutable
 - ImageMagick codec can now read and write `gif` and `apng` including animations
 - GIF decoding now uses `-coalesce` to handle partial frames correctly
+- Redimension filter to change image dimensions
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/README.md
+++ b/README.md
@@ -242,6 +242,15 @@ img.rotate!(90)
 
 ![Transform example](docs/samples/transform.png)
 
+### Redimension
+
+Change how many dimensions an image has or adjust their size.
+
+```ruby
+img = ImageUtil::Image.new(200, 200)
+img.redimension!(300, 300, 2)
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then run

--- a/lib/image_util/filter.rb
+++ b/lib/image_util/filter.rb
@@ -8,6 +8,7 @@ module ImageUtil
     autoload :Draw, "image_util/filter/draw"
     autoload :Resize, "image_util/filter/resize"
     autoload :Transform, "image_util/filter/transform"
+    autoload :Redimension, "image_util/filter/redimension"
 
     autoload :Mixin, "image_util/filter/_mixin"
   end

--- a/lib/image_util/filter/redimension.rb
+++ b/lib/image_util/filter/redimension.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module ImageUtil
+  module Filter
+    module Redimension
+      extend ImageUtil::Filter::Mixin
+
+      def redimension!(*new_dimensions)
+        out = Image.new(*new_dimensions, color_bits: color_bits, channels: channels)
+
+        copy_counts = new_dimensions.map.with_index do |dim, idx|
+          [dim, dimensions[idx] || 1].min
+        end
+
+        ranges = copy_counts[1..] || []
+        each_coordinates(ranges) do |coords|
+          src_buf = row_buffer(coords)
+          out.buffer.copy_1d(src_buf, 0, *coords)
+        end
+
+        initialize_from_buffer(out.buffer)
+        self
+      end
+
+      define_immutable_version :redimension
+
+      private
+
+      def each_coordinates(ranges, prefix = [], &block)
+        if ranges.empty?
+          yield prefix
+        else
+          ranges.first.times do |i|
+            each_coordinates(ranges[1..], prefix + [i], &block)
+          end
+        end
+      end
+
+      def row_buffer(coords)
+        buf = buffer
+        coords_src = coords[0, dimensions.length - 1]
+        coords_src += [0] * (dimensions.length - 1 - coords_src.length)
+        coords_src.reverse_each { |c| buf = buf.last_dimension(c) }
+        buf
+      end
+    end
+  end
+end

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -175,6 +175,7 @@ module ImageUtil
     include Filter::Draw
     include Filter::Resize
     include Filter::Transform
+    include Filter::Redimension
     include Statistic::Colors
 
     def length = dimensions.last

--- a/spec/filter/redimension_spec.rb
+++ b/spec/filter/redimension_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Image do
+  describe '#redimension!' do
+    it 'expands image dimensions and pads with transparency' do
+      img = described_class.new(2, 1) { |x, _| ImageUtil::Color[x] }
+      img.redimension!(3, 2, 2)
+      img.dimensions.should == [3, 2, 2]
+      img[0,0,0].should == ImageUtil::Color[0]
+      img[1,0,0].should == ImageUtil::Color[1]
+      img[2,0,0].should == ImageUtil::Color.new(0,0,0,0)
+      img[0,1,0].should == ImageUtil::Color.new(0,0,0,0)
+      img[0,0,1].should == ImageUtil::Color.new(0,0,0,0)
+    end
+  end
+
+  describe '#redimension' do
+    it 'returns new image without modifying original' do
+      img = described_class.new(2, 1)
+      dup = img.redimension(1, 1)
+      dup.should_not equal(img)
+      dup.dimensions.should == [1, 1]
+      img.dimensions.should == [2, 1]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- implement `Redimension` filter for resizing dimensions using `Buffer#copy_1d`
- expose `Redimension` via autoload and include in Image
- document feature in README and CHANGELOG
- test new filter

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`


------
https://chatgpt.com/codex/tasks/task_e_6882309c3ffc832aab9eb442fa5314af