### PR TITLE
Improve redimension buffer heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Redimension filter to change image dimensions
 - Redimension attempts to resize the existing buffer when increasing height or
   adding a new dimension
+- Improved heuristic for buffer resizing so multi-dimensional images stay intact
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/lib/image_util/filter/redimension.rb
+++ b/lib/image_util/filter/redimension.rb
@@ -42,17 +42,15 @@ module ImageUtil
 
         dims = dimensions
 
-        if new_dimensions.length == dims.length
-          return false unless dims.length >= 2
-          changed = new_dimensions.each_index.reject { |i| new_dimensions[i] == dims[i] }
-          changed.length == 1 &&
-            changed.first == 1 &&
-            new_dimensions[1] >= dims[1]
-        elsif new_dimensions.length == dims.length + 1
-          new_dimensions[0, dims.length] == dims
-        else
-          false
-        end
+        min_len = [dims.length, new_dimensions.length].min
+        idx = 0
+        idx += 1 while idx < min_len && dims[idx] == new_dimensions[idx]
+
+        return false if idx == dims.length && idx == new_dimensions.length
+        return false unless (dims[(idx + 1)..] || []).all? { |d| d == 1 }
+        return false unless (dims[new_dimensions.length..] || []).all? { |d| d == 1 }
+
+        true
       end
 
       def resize_buffer!(new_dimensions)

--- a/spec/filter/redimension_spec.rb
+++ b/spec/filter/redimension_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe ImageUtil::Image do
       img[0,0,0].should == ImageUtil::Color[1]
       img[0,0,1].should == ImageUtil::Color.new(0,0,0,0)
     end
+
+    it 'handles extra dimensions when resizing height' do
+      img = described_class.new(2, 2, 2) { |x,y,z| ImageUtil::Color[x + y*10 + z*100] }
+      img.redimension!(2, 3, 2)
+      img.dimensions.should == [2, 3, 2]
+      img[0,0,1].should == ImageUtil::Color[100]
+      img[0,2,0].should == ImageUtil::Color.new(0,0,0,0)
+    end
   end
 
   describe '#redimension' do


### PR DESCRIPTION
## Summary
- make `fast_redimension?` safer and more permissive
- cover multi-dimensional resize in specs
- document heuristic improvement

## Testing
- `bundle exec rake spec`
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_688349036894832ab4666757fec9c18f