### PR TITLE
Add benchmarking subsystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Redimension filter to change image dimensions
 - Redimension attempts to resize the existing buffer when increasing height or
   adding a new dimension
-- Benchmarking subsystem with `bin/benchmark`
+- Benchmarking subsystem with `bin/benchmark` using `benchmark-ips`
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Redimension filter to change image dimensions
 - Redimension attempts to resize the existing buffer when increasing height or
   adding a new dimension
+- Benchmarking subsystem with `bin/benchmark`
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,6 @@ gem "ffi", "~> 1.16"
 gem "pry", "~> 0.15.2"
 gem "simplecov", "~> 0.22"
 
+gem "benchmark-ips", "~> 2.14"
+
 gem "stackprof", "~> 0.2.27" unless Gem.win_platform?

--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ img = ImageUtil::Image.new(200, 200)
 img.redimension!(300, 300, 2)
 ```
 
+## Benchmarking
+
+Run `bin/benchmark` to execute a small benchmark. It creates a `64×64×64`
+black image several times and prints timing information.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then run

--- a/README.md
+++ b/README.md
@@ -253,8 +253,9 @@ img.redimension!(300, 300, 2)
 
 ## Benchmarking
 
-Run `bin/benchmark` to execute a small benchmark. It creates a `64×64×64`
-black image several times and prints timing information.
+Run `bin/benchmark` to execute a small benchmark. It repeatedly builds a
+`64×64×64` black image for a configurable duration and prints timing
+information.
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,8 @@ RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
 task default: %i[spec rubocop]
+
+desc "Run benchmarks"
+task :bench do
+  ruby File.expand_path("bin/benchmark", __dir__)
+end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -4,5 +4,5 @@
 require "bundler/setup"
 require "image_util"
 
-iterations = (ARGV[0] || 5).to_i
-puts ImageUtil::Benchmarking.image_creation(iterations)
+seconds = (ARGV[0] || 1).to_f
+ImageUtil::Benchmarking.run(seconds)

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "image_util"
+
+iterations = (ARGV[0] || 5).to_i
+puts ImageUtil::Benchmarking.image_creation(iterations)

--- a/lib/image_util.rb
+++ b/lib/image_util.rb
@@ -15,4 +15,5 @@ module ImageUtil
   autoload :Statistic, "image_util/statistic"
   autoload :Terminal, "image_util/terminal"
   autoload :View, "image_util/view"
+  autoload :Benchmarking, "image_util/benchmarking"
 end

--- a/lib/image_util/benchmarking.rb
+++ b/lib/image_util/benchmarking.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "benchmark"
+
+module ImageUtil
+  module Benchmarking
+    module_function
+
+    # Creates a 64x64x64 image filled with black pixels multiple times
+    # to provide a heavy yet quick benchmark.
+    def image_creation(iterations = 5)
+      ::Benchmark.measure do
+        iterations.times do
+          Image.new(64, 64, 64) { :black }
+        end
+      end
+    end
+  end
+end

--- a/lib/image_util/benchmarking.rb
+++ b/lib/image_util/benchmarking.rb
@@ -1,19 +1,22 @@
 # frozen_string_literal: true
 
-require "benchmark"
+require "benchmark/ips"
 
 module ImageUtil
   module Benchmarking
     module_function
 
-    # Creates a 64x64x64 image filled with black pixels multiple times
-    # to provide a heavy yet quick benchmark.
-    def image_creation(iterations = 5)
-      ::Benchmark.measure do
-        iterations.times do
-          Image.new(64, 64, 64) { :black }
-        end
+    # Benchmarks creating a 64×64×64 black image for the given time in seconds.
+    def image_creation(seconds = 1)
+      ::Benchmark.ips do |x|
+        x.warmup = 0
+        x.time = seconds
+        x.report("image_creation") { Image.new(64, 64, 64) { :black } }
       end
+    end
+
+    def run(seconds = 1)
+      image_creation(seconds)
     end
   end
 end

--- a/spec/benchmarking_spec.rb
+++ b/spec/benchmarking_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'benchmark'
+require 'benchmark/ips'
 
 RSpec.describe ImageUtil::Benchmarking do
   it 'runs image creation benchmark' do
-    result = described_class.image_creation(1)
-    result.should be_a(Benchmark::Tms)
+    result = described_class.image_creation(0.1)
+    result.should be_a(Benchmark::IPS::Report)
   end
 end

--- a/spec/benchmarking_spec.rb
+++ b/spec/benchmarking_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+require 'benchmark'
+
+RSpec.describe ImageUtil::Benchmarking do
+  it 'runs image creation benchmark' do
+    result = described_class.image_creation(1)
+    result.should be_a(Benchmark::Tms)
+  end
+end


### PR DESCRIPTION
## Summary
- add benchmarking module and autoload in library
- add bin/benchmark script
- allow running `rake bench`
- document benchmarking support and update CHANGELOG
- test Benchmarking module

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_688349bdbdb8832aa2484ceca4899a12