### PR TITLE
Add CLI support command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
-- Thor based CLI with a `support` command
-- Improved `support` output formatting and added CLI documentation
+- Thor based CLI with a `support` command that lists codec support, default
+  format handlers and detected terminal features
 - Replace Dither implementation with a much faster one
 - Terminal detection for graphic protocols
 - Support Kitty graphics protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Thor based CLI with a `support` command
 - Replace Dither implementation with a much faster one
 - Terminal detection for graphic protocols
 - Support Kitty graphics protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Thor based CLI with a `support` command
+- Improved `support` output formatting and added CLI documentation
 - Replace Dither implementation with a much faster one
 - Terminal detection for graphic protocols
 - Support Kitty graphics protocol

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,6 @@ gem "chunky_png", "~> 1.4"
 gem "ffi", "~> 1.16"
 gem "pry", "~> 0.15.2"
 gem "simplecov", "~> 0.22"
+gem "thor", "~> 1.2"
 
 gem "stackprof", "~> 0.2.27" unless Gem.win_platform?

--- a/README.md
+++ b/README.md
@@ -251,13 +251,17 @@ img = ImageUtil::Image.new(200, 200)
 img.redimension!(300, 300, 2)
 ```
 
+## Command Line
+
+The gem includes a small `image_util` CLI. Run `image_util support` to list
+available codecs and default format handlers. See [docs/cli.md](docs/cli.md) for
+details.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then run
 `rake spec` to execute the tests. You can also run `bin/console` for an
-interactive prompt for experimenting with the library. The `image_util` CLI
-provides a `support` command that lists available codecs and default format
-handlers.
+interactive prompt for experimenting with the library.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,6 @@ looks in Konsole:
 This library supports generating Sixel with either `libsixel`, `ImageMagick` or using a pure-Ruby Sixel generator. For best performance, try to install one of
 the earlier system packages.
 
-`ImageUtil::Terminal.detect_support` reports which terminal capabilities are available:
-
-- `:tty` — basic text terminal
-- `:kitty` — Kitty graphics protocol
-- `:sixel` — SIXEL graphics protocol
 
 ## Color Values
 
@@ -260,8 +255,8 @@ img.redimension!(300, 300, 2)
 ## Command Line
 
 The gem includes a small `image_util` CLI. Run `image_util support` to list
-available codecs and default format handlers. See [docs/cli.md](docs/cli.md) for
-details.
+available codecs, default format handlers and detected terminal features.
+See [docs/cli.md](docs/cli.md) for details.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,9 @@ img.redimension!(300, 300, 2)
 
 After checking out the repo, run `bin/setup` to install dependencies. Then run
 `rake spec` to execute the tests. You can also run `bin/console` for an
-interactive prompt for experimenting with the library.
+interactive prompt for experimenting with the library. The `image_util` CLI
+provides a `support` command that lists available codecs and default format
+handlers.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ looks in Konsole:
 This library supports generating Sixel with either `libsixel`, `ImageMagick` or using a pure-Ruby Sixel generator. For best performance, try to install one of
 the earlier system packages.
 
+`ImageUtil::Terminal.detect_support` reports which terminal capabilities are available:
+
+- `:tty` — basic text terminal
+- `:kitty` — Kitty graphics protocol
+- `:sixel` — SIXEL graphics protocol
+
 ## Color Values
 
 `ImageUtil::Color.from` (also known as `ImageUtil::Color.[]`) accepts several inputs:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,4 @@
+# Command Line Interface
+
+Run `image_util support` to see which codecs are available on your system and
+which codec handles each format by default.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,4 +1,5 @@
 # Command Line Interface
 
-Run `image_util support` to see which codecs are available on your system and
-which codec handles each format by default.
+Run `image_util support` to see which codecs are available on your system,
+which codec handles each format by default, and which terminal features are
+detected.

--- a/exe/image_util
+++ b/exe/image_util
@@ -2,6 +2,6 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "image_util/cli"
+require "image_util"
 
 ImageUtil::CLI.start(ARGV)

--- a/exe/image_util
+++ b/exe/image_util
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "image_util/cli"
+
+ImageUtil::CLI.start(ARGV)

--- a/image_util.gemspec
+++ b/image_util.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "base64"
   spec.add_dependency "ffi", "~> 1.16"
+  spec.add_dependency "thor", "~> 1.2"
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"

--- a/lib/image_util.rb
+++ b/lib/image_util.rb
@@ -15,4 +15,5 @@ module ImageUtil
   autoload :Statistic, "image_util/statistic"
   autoload :Terminal, "image_util/terminal"
   autoload :View, "image_util/view"
+  autoload :CLI, "image_util/cli"
 end

--- a/lib/image_util/cli.rb
+++ b/lib/image_util/cli.rb
@@ -6,18 +6,22 @@ module ImageUtil
   class CLI < Thor
     desc "support", "Display codec support and default codecs"
     def support
+      width = (codec_names + format_names).map(&:length).max
+      use_color = Terminal.detect_support.include?(:tty)
+
       puts "Codecs:"
       codec_names.each do |name|
         mod = Codec.const_get(name)
         supported = !mod.respond_to?(:supported?) || mod.supported?
-        status = supported ? "supported" : "not supported"
-        puts "  #{name} - #{status}"
+        status = supported ? color("supported", 32, use_color) : color("not supported", 31, use_color)
+        puts format("  %-#{width}s  %s", name, status)
       end
+
       puts "\nFormats:"
       format_names.each do |fmt|
         codec = default_codec(fmt)
         codec_name = codec ? codec.to_s : "none"
-        puts "  #{fmt} - #{codec_name}"
+        puts format("  %-#{width}s  %s", fmt, codec_name)
       end
     end
 
@@ -36,6 +40,10 @@ module ImageUtil
           return r[:codec]
         end
         nil
+      end
+
+      def color(text, code, enable)
+        enable ? "\e[#{code}m#{text}\e[0m" : text
       end
     end
   end

--- a/lib/image_util/cli.rb
+++ b/lib/image_util/cli.rb
@@ -4,7 +4,7 @@ require "thor"
 
 module ImageUtil
   class CLI < Thor
-    desc "support", "Display codec support and default codecs"
+    desc "support", "Display codec support, default codecs and terminal features"
     def support
       width = (codec_names + format_names).map(&:length).max
       use_color = Terminal.detect_support.include?(:tty)
@@ -22,6 +22,11 @@ module ImageUtil
         codec = default_codec(fmt)
         codec_name = codec ? codec.to_s : "none"
         puts format("  %-#{width}s  %s", fmt, codec_name)
+      end
+
+      puts "\nTerminal features:"
+      Terminal.detect_support.each do |feat|
+        puts "  #{color(feat, 34, use_color)}"
       end
     end
 

--- a/lib/image_util/cli.rb
+++ b/lib/image_util/cli.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "thor"
+
+module ImageUtil
+  class CLI < Thor
+    desc "support", "Display codec support and default codecs"
+    def support
+      puts "Codecs:"
+      codec_names.each do |name|
+        mod = Codec.const_get(name)
+        supported = !mod.respond_to?(:supported?) || mod.supported?
+        status = supported ? "supported" : "not supported"
+        puts "  #{name} - #{status}"
+      end
+      puts "\nFormats:"
+      format_names.each do |fmt|
+        codec = default_codec(fmt)
+        codec_name = codec ? codec.to_s : "none"
+        puts "  #{fmt} - #{codec_name}"
+      end
+    end
+
+    no_commands do
+      def codec_names = Codec.constants.grep_v(/^_/).sort
+
+      def format_names = (Codec.encoders + Codec.decoders).flat_map { |r| r[:formats] }.uniq.sort
+
+      def default_codec(fmt)
+        Codec.encoders.each do |r|
+          next unless r[:formats].include?(fmt.to_s)
+
+          codec_mod = Codec.const_get(r[:codec])
+          next if codec_mod.respond_to?(:supported?) && !codec_mod.supported?(fmt.to_sym)
+
+          return r[:codec]
+        end
+        nil
+      end
+    end
+  end
+end

--- a/spec/cli/support_spec.rb
+++ b/spec/cli/support_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'image_util/cli'
+require 'stringio'
+
+def capture_stdout
+  old = $stdout
+  out = StringIO.new
+  $stdout = out
+  yield
+  out.string
+ensure
+  $stdout = old
+end
+
+RSpec.describe ImageUtil::CLI do
+  it 'prints codec and format information' do
+    allow(ImageUtil::Codec::Pam).to receive(:supported?).and_return(true)
+    allow(ImageUtil::Codec::Kitty).to receive(:supported?).and_return(false)
+    allow(ImageUtil::Codec::Libpng).to receive(:supported?).and_return(false)
+    allow(ImageUtil::Codec::Libturbojpeg).to receive(:supported?).and_return(true)
+    allow(ImageUtil::Codec::Libsixel).to receive(:supported?).and_return(true)
+    allow(ImageUtil::Codec::ImageMagick).to receive(:supported?).and_return(true)
+    allow(ImageUtil::Codec::ChunkyPng).to receive(:supported?).and_return(true)
+    allow(ImageUtil::Codec::RubySixel).to receive(:supported?).and_return(false)
+
+    output = capture_stdout { described_class.start(%w[support]) }
+    output.should include('Pam - supported')
+    output.should include('Kitty - not supported')
+    output.should include('png - ImageMagick')
+    output.should include('jpeg - Libturbojpeg')
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe ImageUtil::CLI do
     allow(ImageUtil::Codec::RubySixel).to receive(:supported?).and_return(false)
 
     output = capture_stdout { described_class.start(%w[support]) }
-    output.should include('Pam - supported')
-    output.should include('Kitty - not supported')
-    output.should include('png - ImageMagick')
-    output.should include('jpeg - Libturbojpeg')
+    output.should match(/Pam\s+supported/)
+    output.should match(/Kitty\s+not supported/)
+    output.should match(/png\s+ImageMagick/)
+    output.should match(/jpeg\s+Libturbojpeg/)
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -23,10 +23,14 @@ RSpec.describe ImageUtil::CLI do
     allow(ImageUtil::Codec::ChunkyPng).to receive(:supported?).and_return(true)
     allow(ImageUtil::Codec::RubySixel).to receive(:supported?).and_return(false)
 
+    allow(ImageUtil::Terminal).to receive(:detect_support).and_return([:sixel])
+
     output = capture_stdout { described_class.start(%w[support]) }
     output.should match(/Pam\s+supported/)
     output.should match(/Kitty\s+not supported/)
     output.should match(/png\s+ImageMagick/)
     output.should match(/jpeg\s+Libturbojpeg/)
+    output.should match(/Terminal features:/)
+    output.should match(/sixel/)
   end
 end


### PR DESCRIPTION
## Summary
- add CLI thor-based `image_util` executable
- implement `support` command to show supported codecs and default format handlers
- document CLI in README
- mention CLI in CHANGELOG
- add spec for CLI
- add thor dependency

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_68834a0a346c832a949ef97566b78efe