### PR TITLE
Add Colors filter and enhance bitmap_text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   redimension filter
 - Add `BitmapFont` with a sample hand crafted font, add `bitmap_text` generator.
 - `Color#*` can now accept another `Color` to multiply channels
+- Add `Colors` filter with `color_multiply!` and alias `*`
+- `bitmap_text` accepts multiline strings and supports colorization
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `Color#*` can now accept another `Color` to multiply channels
 - Add `Colors` filter with `color_multiply!` and alias `*`
 - `bitmap_text` accepts multiline strings and supports colorization
+- `bitmap_text` supports left, center and right alignment
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add `Colors` filter with `color_multiply!` and alias `*`
 - `bitmap_text` accepts multiline strings and supports colorization
 - `bitmap_text` supports left, center and right alignment
+- Add `BitmapText` filter for overlaying text onto images
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ img = ImageUtil::Image.new(64, 32) { [255, 255, 255, 128] }
 img * :red
 ```
 
+### Bitmap Text
+
+Render simple text using the bundled bitmap font. Text can be aligned left,
+center or right.
+
+```ruby
+img = ImageUtil::Image.bitmap_text("Hello\nWorld", align: :center, color: :red)
+```
+
 ### Redimension
 
 Change how many dimensions an image has or adjust their size.

--- a/README.md
+++ b/README.md
@@ -254,11 +254,11 @@ img * :red
 
 ### Bitmap Text
 
-Render simple text using the bundled bitmap font. Text can be aligned left,
-center or right.
+Overlay text using the bundled bitmap font.
 
 ```ruby
-img = ImageUtil::Image.bitmap_text("Hello\nWorld", align: :center, color: :red)
+img = ImageUtil::Image.new(64, 32) { [0, 0, 0] }
+img.bitmap_text!("Hi", 4, 4, color: :yellow)
 ```
 
 ### Redimension

--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ img.rotate!(90)
 
 ![Transform example](docs/samples/transform.png)
 
+### Colors
+
+Multiply all pixels by a color.
+
+```ruby
+img = ImageUtil::Image.new(64, 32) { [255, 255, 255, 128] }
+img * :red
+```
+
 ### Redimension
 
 Change how many dimensions an image has or adjust their size.

--- a/lib/image_util/color.rb
+++ b/lib/image_util/color.rb
@@ -183,8 +183,8 @@ module ImageUtil
       when Numeric
         Color.new(r, g, b, (a * other).clamp(0, 255))
       when Color
-        Color.new(*map.with_index do |c,idx|
-          oc = other[idx] || idx == 3 ? 255 : 0
+        Color.new(*map.with_index do |c, idx|
+          oc = other[idx] || (idx == 3 ? 255 : 0)
           c * oc / 255
         end)
       else

--- a/lib/image_util/filter.rb
+++ b/lib/image_util/filter.rb
@@ -9,6 +9,7 @@ module ImageUtil
     autoload :Resize, "image_util/filter/resize"
     autoload :Transform, "image_util/filter/transform"
     autoload :Redimension, "image_util/filter/redimension"
+    autoload :Colors, "image_util/filter/colors"
 
     autoload :Mixin, "image_util/filter/_mixin"
   end

--- a/lib/image_util/filter.rb
+++ b/lib/image_util/filter.rb
@@ -10,6 +10,7 @@ module ImageUtil
     autoload :Transform, "image_util/filter/transform"
     autoload :Redimension, "image_util/filter/redimension"
     autoload :Colors, "image_util/filter/colors"
+    autoload :BitmapText, "image_util/filter/bitmap_text"
 
     autoload :Mixin, "image_util/filter/_mixin"
   end

--- a/lib/image_util/filter/bitmap_text.rb
+++ b/lib/image_util/filter/bitmap_text.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ImageUtil
+  module Filter
+    module BitmapText
+      extend ImageUtil::Filter::Mixin
+
+      def bitmap_text!(text, x = 0, y = 0, **kwargs)
+        paste!(Image.bitmap_text(text, **kwargs), x, y)
+      end
+
+      define_immutable_version :bitmap_text
+    end
+  end
+end

--- a/lib/image_util/filter/bitmap_text.rb
+++ b/lib/image_util/filter/bitmap_text.rb
@@ -5,8 +5,10 @@ module ImageUtil
     module BitmapText
       extend ImageUtil::Filter::Mixin
 
-      def bitmap_text!(text, x = 0, y = 0, **kwargs)
-        paste!(Image.bitmap_text(text, **kwargs), x, y)
+      def bitmap_text!(text, *location, **kwargs)
+        loc = location.dup
+        loc += [0] * (dimensions.length - loc.length)
+        paste!(Image.bitmap_text(text, **kwargs), *loc)
       end
 
       define_immutable_version :bitmap_text

--- a/lib/image_util/filter/colors.rb
+++ b/lib/image_util/filter/colors.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ImageUtil
+  module Filter
+    module Colors
+      extend ImageUtil::Filter::Mixin
+
+      def color_multiply!(color)
+        col = Color.from(color)
+        each_pixel_location do |loc|
+          self[*loc] = self[*loc] * col
+        end
+        self
+      end
+
+      define_immutable_version :color_multiply
+
+      alias * color_multiply
+    end
+  end
+end

--- a/lib/image_util/generator/bitmap_text.rb
+++ b/lib/image_util/generator/bitmap_text.rb
@@ -3,9 +3,25 @@
 module ImageUtil
   module Generator
     module BitmapText
-      def bitmap_text(text, font: BitmapFont.default_font)
+      def bitmap_text(text, font: BitmapFont.default_font, color: nil)
         fnt = BitmapFont.cached_load(font)
-        fnt.render_line_of_text(text)
+        lines = text.split("\n")
+
+        rendered = lines.map { |line| fnt.render_line_of_text(line) }
+
+        width  = rendered.map(&:width).max || 0
+        height = rendered.map(&:height).first.to_i * rendered.length
+        height += rendered.length - 1 if rendered.length > 1
+
+        out = Image.new(width, height)
+        y = 0
+        rendered.each do |img|
+          out.paste!(img, 0, y)
+          y += img.height + 1
+        end
+
+        out *= color if color
+        out
       end
     end
   end

--- a/lib/image_util/generator/bitmap_text.rb
+++ b/lib/image_util/generator/bitmap_text.rb
@@ -3,7 +3,7 @@
 module ImageUtil
   module Generator
     module BitmapText
-      def bitmap_text(text, font: BitmapFont.default_font, color: nil)
+      def bitmap_text(text, font: BitmapFont.default_font, color: nil, align: :left)
         fnt = BitmapFont.cached_load(font)
         lines = text.split("\n")
 
@@ -16,7 +16,17 @@ module ImageUtil
         out = Image.new(width, height)
         y = 0
         rendered.each do |img|
-          out.paste!(img, 0, y)
+          x = case align
+              when :left
+                0
+              when :center
+                (width - img.width) / 2
+              when :right
+                width - img.width
+              else
+                raise ArgumentError, "invalid alignment #{align.inspect}"
+              end
+          out.paste!(img, x, y)
           y += img.height + 1
         end
 

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -177,6 +177,7 @@ module ImageUtil
     include Filter::Transform
     include Filter::Redimension
     include Filter::Colors
+    include Filter::BitmapText
     include Statistic::Colors
     extend Generator::BitmapText
 

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -176,6 +176,7 @@ module ImageUtil
     include Filter::Resize
     include Filter::Transform
     include Filter::Redimension
+    include Filter::Colors
     include Statistic::Colors
     extend Generator::BitmapText
 

--- a/spec/filter/bitmap_text_spec.rb
+++ b/spec/filter/bitmap_text_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Image do
+  describe '#bitmap_text!' do
+    it 'pastes rendered text at location' do
+      base = described_class.new(16, 16) { ImageUtil::Color[0] }
+      font = ImageUtil::BitmapFont.default_font
+      text = described_class.bitmap_text('A', font: font)
+      base.bitmap_text!('A', 2, 3, font: font)
+      text.each_pixel_location do |(x, y)|
+        base[x + 2, y + 3].should == text[x, y]
+      end
+    end
+  end
+
+  describe '#bitmap_text' do
+    it 'returns new image without modifying original' do
+      img = described_class.new(4, 4)
+      dup = img.bitmap_text('A')
+      dup.should_not equal(img)
+    end
+  end
+end

--- a/spec/filter/bitmap_text_spec.rb
+++ b/spec/filter/bitmap_text_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe ImageUtil::Image do
         base[x + 2, y + 3].should == text[x, y]
       end
     end
+
+    it 'accepts coordinates for extra dimensions' do
+      base = described_class.new(16, 16, 2) { ImageUtil::Color[0] }
+      font = ImageUtil::BitmapFont.default_font
+      text = described_class.bitmap_text('A', font: font)
+      base.bitmap_text!('A', 1, 1, 1, font: font)
+      text.each_pixel_location do |(x, y)|
+        base[x + 1, y + 1, 1].should == text[x, y]
+      end
+      base[1, 1, 0].should == ImageUtil::Color[0]
+    end
   end
 
   describe '#bitmap_text' do

--- a/spec/filter/colors_spec.rb
+++ b/spec/filter/colors_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Image do
+  describe '#color_multiply!' do
+    it 'multiplies image colors in place' do
+      img = described_class.new(1,1) { ImageUtil::Color[100, 200, 50] }
+      img.color_multiply!(ImageUtil::Color[128, 64, 255])
+      expected = ImageUtil::Color[100, 200, 50] * ImageUtil::Color[128, 64, 255]
+      img[0,0].r.should be_within(0.01).of(expected.r)
+      img[0,0].g.should be_within(0.01).of(expected.g)
+      img[0,0].b.should be_within(0.01).of(expected.b)
+    end
+  end
+
+  describe '#color_multiply' do
+    it 'returns new image without modifying original' do
+      img = described_class.new(1,1) { ImageUtil::Color[10,20,30] }
+      dup = img.color_multiply(ImageUtil::Color[255,0,0])
+      dup.should_not equal(img)
+      dup[0,0].should == img[0,0] * ImageUtil::Color[255,0,0]
+      img[0,0].should == ImageUtil::Color[10,20,30]
+    end
+  end
+
+  describe '#*' do
+    it 'aliases color_multiply' do
+      img = described_class.new(1,1) { ImageUtil::Color[20,40,60] }
+      dup = img * ImageUtil::Color[0,255,0]
+      dup[0,0].should == img.color_multiply(ImageUtil::Color[0,255,0])[0,0]
+    end
+  end
+end

--- a/spec/generator/bitmap_text_spec.rb
+++ b/spec/generator/bitmap_text_spec.rb
@@ -10,5 +10,16 @@ RSpec.describe ImageUtil::Generator::BitmapText do
       red = ImageUtil::Color[:red]
       img.each_pixel.any? { |c| c.r == red.r && c.g == red.g && c.b == red.b && c.a > 0 }.should be true
     end
+
+    it 'aligns text according to option' do
+      font = ImageUtil::BitmapFont.default_font
+      img = ImageUtil::Image.bitmap_text("AB\nA", font: font, align: :right)
+      loader = ImageUtil::BitmapFont.cached_load(font)
+      width  = loader.render_line_of_text("AB").width
+      line_height = loader.render_line_of_text("A").height
+      img.width.should == width
+      y = line_height + 1
+      (0...(width - loader.render_line_of_text("A").width)).all? { |x| img[x, y].a.zero? }.should be true
+    end
   end
 end

--- a/spec/generator/bitmap_text_spec.rb
+++ b/spec/generator/bitmap_text_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Generator::BitmapText do
+  describe '#bitmap_text' do
+    it 'renders multiline colored text' do
+      font = ImageUtil::BitmapFont.default_font
+      img = ImageUtil::Image.bitmap_text("A\nB", font: font, color: :red)
+      line_height = ImageUtil::BitmapFont.cached_load(font).render_line_of_text("A").height
+      img.height.should == line_height * 2 + 1
+      red = ImageUtil::Color[:red]
+      img.each_pixel.any? { |c| c.r == red.r && c.g == red.g && c.b == red.b && c.a > 0 }.should be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- implement `color_multiply!` filter and expose `*` for color multiplication
- support multiline & colored text in `bitmap_text`
- document new Colors filter in README
- update CHANGELOG
- test new functionality

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_688371e01b38832ab2a4f5164178133c