### PR TITLE
Fix bitmap_text alpha overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `bitmap_text` accepts multiline strings and supports colorization
 - `bitmap_text` supports left, center and right alignment
 - Add `BitmapText` filter for overlaying text onto images
+- `bitmap_text` filter now always respects an alpha channel when pasting text
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/lib/image_util/filter/bitmap_text.rb
+++ b/lib/image_util/filter/bitmap_text.rb
@@ -8,7 +8,7 @@ module ImageUtil
       def bitmap_text!(text, *location, **kwargs)
         loc = location.dup
         loc += [0] * (dimensions.length - loc.length)
-        paste!(Image.bitmap_text(text, **kwargs), *loc)
+        paste!(Image.bitmap_text(text, **kwargs), *loc, respect_alpha: true)
       end
 
       define_immutable_version :bitmap_text

--- a/spec/filter/bitmap_text_spec.rb
+++ b/spec/filter/bitmap_text_spec.rb
@@ -3,24 +3,56 @@ require 'spec_helper'
 RSpec.describe ImageUtil::Image do
   describe '#bitmap_text!' do
     it 'pastes rendered text at location' do
-      base = described_class.new(16, 16) { ImageUtil::Color[0] }
+      base_color = ImageUtil::Color[0]
+      base = described_class.new(16, 16) { base_color }
       font = ImageUtil::BitmapFont.default_font
       text = described_class.bitmap_text('A', font: font)
       base.bitmap_text!('A', 2, 3, font: font)
       text.each_pixel_location do |(x, y)|
-        base[x + 2, y + 3].should == text[x, y]
+        expected = if text[x, y].a.zero?
+                     base_color
+                   else
+                     base_color + text[x, y]
+                   end
+        expected = ImageUtil::Color.new(*expected.map(&:to_i))
+        base[x + 2, y + 3].should == expected
       end
     end
 
     it 'accepts coordinates for extra dimensions' do
-      base = described_class.new(16, 16, 2) { ImageUtil::Color[0] }
+      base_color = ImageUtil::Color[0]
+      base = described_class.new(16, 16, 2) { base_color }
       font = ImageUtil::BitmapFont.default_font
       text = described_class.bitmap_text('A', font: font)
       base.bitmap_text!('A', 1, 1, 1, font: font)
       text.each_pixel_location do |(x, y)|
-        base[x + 1, y + 1, 1].should == text[x, y]
+        expected = if text[x, y].a.zero?
+                     base_color
+                   else
+                     base_color + text[x, y]
+                   end
+        expected = ImageUtil::Color.new(*expected.map(&:to_i))
+        base[x + 1, y + 1, 1].should == expected
       end
-      base[1, 1, 0].should == ImageUtil::Color[0]
+      base[1, 1, 0].should == base_color
+    end
+
+    it 'respects alpha channel of rendered text' do
+      font = ImageUtil::BitmapFont.default_font
+      color = ImageUtil::Color[20, 0, 0, 128]
+      text  = described_class.bitmap_text('A', font: font, color: color)
+      base_color = ImageUtil::Color[10, 20, 30]
+      base = described_class.new(text.width, text.height) { base_color }
+      base.bitmap_text!('A', 0, 0, font: font, color: color)
+      text.each_pixel_location do |(x, y)|
+        expected = if text[x, y].a.zero?
+                     base_color
+                   else
+                     base_color + text[x, y]
+                   end
+        expected = ImageUtil::Color.new(*expected.map(&:to_i))
+        base[x, y].should == expected
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- ensure BitmapText filter uses alpha blending when pasting text
- test that bitmap_text! respects alpha channel
- document fix in CHANGELOG

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_68838887d608832ab24607ab2064d732