### PR TITLE
Filter unsupported codecs from coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `bitmap_text` supports left, center and right alignment
 - Add `BitmapText` filter for overlaying text onto images
 - `bitmap_text` filter now always respects an alpha channel when pasting text
+- Open ImageMagick codec pipes in binary mode for Windows compatibility
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/lib/image_util/codec/image_magick.rb
+++ b/lib/image_util/codec/image_magick.rb
@@ -39,7 +39,7 @@ module ImageUtil
           end
           pam = Codec::Pam.encode(:pam, img)
 
-          IO.popen(["magick", "pam:-", "#{fmt}:-"], "r+") do |proc_io|
+          IO.popen(["magick", "pam:-", "#{fmt}:-"], "r+b") do |proc_io|
             proc_io << pam
             proc_io.close_write
             proc_io.read
@@ -47,7 +47,7 @@ module ImageUtil
         else
           frames = image.buffer.last_dimension_split.map { |b| Image.from_buffer(b) }
           stream = frames.map { |f| Codec::Pam.encode(:pam, f) }.join
-          IO.popen(["magick", "pam:-", "#{fmt}:-"], "r+") do |proc_io|
+          IO.popen(["magick", "pam:-", "#{fmt}:-"], "r+b") do |proc_io|
             proc_io << stream
             proc_io.close_write
             proc_io.read
@@ -61,7 +61,7 @@ module ImageUtil
         cmd = ["magick", "#{format}:-"]
         cmd << "-coalesce" if %i[gif apng].include?(format.to_s.downcase.to_sym)
         cmd << "pam:-"
-        IO.popen(cmd, "r+") do |proc_io|
+        IO.popen(cmd, "r+b") do |proc_io|
           proc_io << data
           proc_io.close_write
 

--- a/spec/codec/image_magick_spec.rb
+++ b/spec/codec/image_magick_spec.rb
@@ -1,92 +1,40 @@
 require 'spec_helper'
 
 RSpec.describe ImageUtil::Codec::ImageMagick do
-  let(:img) { ImageUtil::Image.new(1, 1) { ImageUtil::Color[255, 0, 0] } }
-  let(:pam) { ImageUtil::Codec::Pam.encode(:pam, img) }
-
   before do
-    allow(described_class).to receive(:magick_available?).and_return(true)
+    skip 'ImageMagick not available' unless described_class.supported?(:png)
   end
 
-  it 'encodes using ImageMagick' do
-    proc_io = StringIO.new
-    def proc_io.close_write; end
-    def proc_io.read; 'OUT' end
-    allow(IO).to receive(:popen).and_yield(proc_io)
+  let(:img) { ImageUtil::Image.new(1, 1) { ImageUtil::Color[255, 0, 0] } }
 
-    out = described_class.encode(:png, img)
-    out.should == 'OUT'
-    proc_io.string.bytes.should == pam.bytes
+  it 'encodes and decodes PNG images' do
+    data = described_class.encode(:png, img)
+    data.start_with?("\x89PNG\r\n\x1a\n".b).should be true
+
+    decoded = described_class.decode(:png, data)
+    decoded.dimensions.should == [1, 1]
+    decoded[0, 0].should == ImageUtil::Color[255, 0, 0]
   end
 
-  it 'encodes JPEG' do
-    proc_io = StringIO.new
-    def proc_io.close_write; end
-    def proc_io.read; 'JOUT' end
-    allow(IO).to receive(:popen).and_yield(proc_io)
+  it 'encodes and decodes JPEG images' do
+    data = described_class.encode(:jpeg, img)
+    data.start_with?("\xFF\xD8".b).should be true
 
-    out = described_class.encode(:jpeg, img)
-    out.should == 'JOUT'
-    proc_io.string.bytes.should == pam.bytes
+    decoded = described_class.decode(:jpeg, data)
+    decoded.dimensions.should == [1, 1]
   end
 
-  it 'encodes GIF animation' do
+  it 'handles GIF animations' do
     anim = ImageUtil::Image.new(1, 1, 2) { |_, _, z| ImageUtil::Color[z * 255] }
-    frame0 = ImageUtil::Codec::Pam.encode(:pam, ImageUtil::Image.from_buffer(anim.buffer.last_dimension_split[0]))
-    frame1 = ImageUtil::Codec::Pam.encode(:pam, ImageUtil::Image.from_buffer(anim.buffer.last_dimension_split[1]))
-
-    proc_io = StringIO.new
-    def proc_io.read; 'GOUT' end
-    allow(IO).to receive(:popen).and_yield(proc_io)
-
-    out = described_class.encode(:gif, anim)
-    out.should == 'GOUT'
-    proc_io.string.bytes.should == (frame0 + frame1).bytes
-  end
-
-  it 'decodes using ImageMagick' do
-    proc_io = StringIO.new(pam)
-    def proc_io.close_write; end
-    def proc_io.<<(_str); end
-    allow(IO).to receive(:popen).and_yield(proc_io)
-
-    decoded = described_class.decode(:png, 'PNG')
-    decoded.dimensions.should == [1, 1]
-  end
-
-  it 'decodes JPEG' do
-    proc_io = StringIO.new(pam)
-    def proc_io.close_write; end
-    def proc_io.<<(_str); end
-    allow(IO).to receive(:popen).and_yield(proc_io)
-
-    decoded = described_class.decode(:jpeg, 'JPG')
-    decoded.dimensions.should == [1, 1]
-  end
-
-  it 'decodes animated GIF' do
-    frame = ImageUtil::Image.new(1, 1) { ImageUtil::Color[0] }
-    pam0 = ImageUtil::Codec::Pam.encode(:pam, frame)
-    pam1 = ImageUtil::Codec::Pam.encode(:pam, frame)
-    proc_io = StringIO.new(pam0 + pam1)
-    def proc_io.close_write; end
-    def proc_io.<<(_str); end
-    IO.should_receive(:popen).with(["magick", "gif:-", "-coalesce", "pam:-"], "r+").and_yield(proc_io)
-
-    decoded = described_class.decode(:gif, 'GIF')
+    data = described_class.encode(:gif, anim)
+    decoded = described_class.decode(:gif, data)
     decoded.dimensions.should == [1, 1, 2]
   end
 
-  it 'decodes animated PNG' do
-    frame = ImageUtil::Image.new(1, 1) { ImageUtil::Color[0] }
-    pam0 = ImageUtil::Codec::Pam.encode(:pam, frame)
-    pam1 = ImageUtil::Codec::Pam.encode(:pam, frame)
-    proc_io = StringIO.new(pam0 + pam1)
-    def proc_io.close_write; end
-    def proc_io.<<(_str); end
-    IO.should_receive(:popen).with(["magick", "apng:-", "-coalesce", "pam:-"], "r+").and_yield(proc_io)
-
-    decoded = described_class.decode(:apng, 'APNG')
+  it 'handles APNG animations' do
+    anim = ImageUtil::Image.new(1, 1, 2) { |_, _, z| ImageUtil::Color[z * 255] }
+    data = described_class.encode(:apng, anim)
+    decoded = described_class.decode(:apng, data)
     decoded.dimensions.should == [1, 1, 2]
   end
 end

--- a/spec/codec/libturbojpeg_spec.rb
+++ b/spec/codec/libturbojpeg_spec.rb
@@ -1,66 +1,26 @@
 require 'spec_helper'
 
 RSpec.describe ImageUtil::Codec::Libturbojpeg do
-  let(:img) { ImageUtil::Image.new(1, 1) { ImageUtil::Color[255, 0, 0] } }
-
-  context 'when library is unavailable' do
-    before do
-      stub_const("#{described_class.name}::AVAILABLE", false)
-    end
-
-    it 'raises on encode' do
-      -> { described_class.encode(:jpeg, img) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
-    end
-
-    it 'raises on decode' do
-      -> { described_class.decode(:jpeg, 'data') }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
-    end
+  before do
+    skip 'libturbojpeg not available' unless described_class.supported?
   end
 
-  context 'with stubbed FFI' do
-    before do
-      stub_const("#{described_class.name}::AVAILABLE", true)
-      allow(described_class).to receive(:tjInitCompress).and_return(FFI::Pointer.new(1))
-      allow(described_class).to receive(:tjInitDecompress).and_return(FFI::Pointer.new(1))
-      allow(described_class).to receive(:tjDestroy)
-      allow(described_class).to receive(:tjFree)
-      allow(described_class).to receive(:tjCompress2) do |*args|
-        ptrptr = args[6]
-        sizeptr = args[7]
-        jpeg = 'JPEG'
-        mem = FFI::MemoryPointer.from_string(jpeg)
-        ptrptr.write_pointer(mem)
-        sizeptr.write_ulong(jpeg.bytesize)
-        0
-      end
-      allow(described_class).to receive(:tjDecompressHeader3) do |*args|
-        wptr = args[3]
-        hptr = args[4]
-        wptr.write_int(1)
-        hptr.write_int(1)
-        0
-      end
-      allow(described_class).to receive(:tjDecompress2) do |*args|
-        dst = args[3]
-        w = args[4]
-        h = args[6]
-        dst.put_bytes(0, "\x00" * w * h * 4)
-        0
-      end
-      stub_const("#{described_class.name}::DECOMPRESS_HEADER_FUNC", :tjDecompressHeader3)
-    end
+  let(:img) { ImageUtil::Image.new(1, 1) { ImageUtil::Color[255, 0, 0] } }
 
-    it 'encodes and decodes a JPEG image' do
-      data = described_class.encode(:jpeg, img)
-      data.should == 'JPEG'
+  it 'encodes and decodes a JPEG image' do
+    data = described_class.encode(:jpeg, img)
+    data.start_with?("\xFF\xD8".b).should be true
 
-      decoded = described_class.decode(:jpeg, data)
-      decoded.dimensions.should == [1, 1]
-    end
+    decoded = described_class.decode(:jpeg, data)
+    decoded.dimensions.should == [1, 1]
+    c = decoded[0, 0]
+    c.r.should be_between(250, 255)
+    c.g.should == 0
+    c.b.should == 0
+  end
 
-    it 'raises for unsupported color depth' do
-      bad = ImageUtil::Image.new(1, 1, color_bits: 16)
-      -> { described_class.encode(:jpeg, bad) }.should raise_error(ArgumentError)
-    end
+  it 'raises for unsupported color depth' do
+    bad = ImageUtil::Image.new(1, 1, color_bits: 16)
+    -> { described_class.encode(:jpeg, bad) }.should raise_error(ArgumentError)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,17 @@ end
 
 require "image_util"
 
+# Don't count coverage for codecs not supported by the current environment
+ImageUtil::Codec.constants.each do |name|
+  const = ImageUtil::Codec.const_get(name)
+  next unless const.is_a?(Module)
+  next unless const.respond_to?(:supported?)
+  next if const.supported?
+
+  file = "lib/image_util/codec/#{name.to_s.gsub(/([a-z\d])([A-Z])/, '\\1_\\2').downcase}.rb"
+  SimpleCov.add_filter(file)
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
## Summary
- exclude codec files if the corresponding library isn't available
- test Libturbojpeg codec with the real library
- run ImageMagick codec tests only when the `magick` command is present

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_68838a970190832a870db20f59d59c57