### PR TITLE
Infer format from file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `bitmap_text` supports left, center and right alignment
 - Add `BitmapText` filter for overlaying text onto images
 - `bitmap_text` filter now always respects an alpha channel when pasting text
+- Format inference from file extension in `Image#to_file`
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ img.draw_line([0,0], [69,45], :blue)
 ![Pipe load example](docs/samples/pipe.png)
 
 The same formats can be written back using `to_string` or `to_file`.
+When saving to a file path, `to_file` can infer the format from the file extension.
 
 ```ruby
-img.to_file("out.png", :png)
+img.to_file("out.png")
 binary = img.to_string(:jpeg)
 ```
 

--- a/lib/image_util.rb
+++ b/lib/image_util.rb
@@ -12,6 +12,7 @@ module ImageUtil
   autoload :Util, "image_util/util"
   autoload :Codec, "image_util/codec"
   autoload :Magic, "image_util/magic"
+  autoload :Extension, "image_util/extension"
   autoload :Filter, "image_util/filter"
   autoload :Generator, "image_util/generator"
   autoload :Statistic, "image_util/statistic"

--- a/lib/image_util/extension.rb
+++ b/lib/image_util/extension.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ImageUtil
+  module Extension
+    EXTENSIONS = {
+      pam: [".pam"],
+      png: [".png"],
+      jpeg: [".jpg", ".jpeg"],
+      gif: [".gif"],
+      apng: [".apng"]
+    }.freeze
+
+    LOOKUP = EXTENSIONS.flat_map { |fmt, exts| exts.map { |e| [e, fmt] } }.to_h.freeze
+
+    module_function
+
+    def detect(path)
+      return nil unless path
+
+      ext = File.extname(path.to_s).downcase
+      LOOKUP[ext]
+    end
+  end
+end

--- a/lib/image_util/image.rb
+++ b/lib/image_util/image.rb
@@ -191,11 +191,16 @@ module ImageUtil
       Codec.encode(format, self, codec: codec, **kwargs)
     end
 
-    def to_file(path_or_io, format, codec: nil, **kwargs)
+    def to_file(path_or_io, format = nil, codec: nil, **kwargs)
       if path_or_io.respond_to?(:write)
+        raise ArgumentError, "format required" unless format
+
         path_or_io.binmode if path_or_io.respond_to?(:binmode)
         Codec.encode_io(format, self, path_or_io, codec: codec, **kwargs)
       else
+        format ||= Extension.detect(path_or_io)
+        raise ArgumentError, "could not detect format" unless format
+
         File.open(path_or_io, "wb") do |io|
           Codec.encode_io(format, self, io, codec: codec, **kwargs)
         end

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Extension do
+  it 'returns nil for nil path' do
+    described_class.detect(nil).should be_nil
+  end
+
+  it 'detects formats from extensions' do
+    described_class.detect('file.png').should == :png
+    described_class.detect('file.jpeg').should == :jpeg
+    described_class.detect('file.JPG').should == :jpeg
+    described_class.detect('file.pam').should == :pam
+    described_class.detect('file.gif').should == :gif
+    described_class.detect('file.apng').should == :apng
+  end
+
+  it 'returns nil for unknown extensions' do
+    described_class.detect('file.xyz').should be_nil
+  end
+end

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -139,6 +139,16 @@ RSpec.describe ImageUtil::Image do
     end
   end
 
+  it 'infers format from extension' do
+    img = described_class.new(1,1) { ImageUtil::Color[1,2,3] }
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'tmp.pam')
+      img.to_file(path)
+      other = described_class.from_file(path, :pam)
+      other[0,0].should == ImageUtil::Color[1,2,3,255]
+    end
+  end
+
   it 'infers format from file' do
     img = described_class.new(1,1) { ImageUtil::Color[6,5,4] }
     Tempfile.create('img') do |f|


### PR DESCRIPTION
## Summary
- detect file format from extension
- use extension detection when writing images if format isn't given
- document extension inference for `to_file`

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_68838b566e8c832aa827d09f21a431ca