### PR TITLE
Use Pam codec when reading ImageMagick frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `bitmap_text` filter now always respects an alpha channel when pasting text
 - Open ImageMagick codec pipes in binary mode for Windows compatibility
 - Format inference from file extension in `Image#to_file`
+- ImageMagick codec now reads PAM frames using the Pam codec
 
 ## [0.2.0] - 2025-07-21
 - Ruby Sixel encoder now sets pixel aspect ratio metadata to display correctly in Windows Terminal

--- a/lib/image_util/codec/image_magick.rb
+++ b/lib/image_util/codec/image_magick.rb
@@ -66,7 +66,7 @@ module ImageUtil
           proc_io.close_write
 
           frames = []
-          while (frame = read_pam_frame(proc_io))
+          while (frame = Codec::Pam.decode_frame(proc_io))
             frames << frame
           end
 
@@ -84,35 +84,6 @@ module ImageUtil
             img
           end
         end
-      end
-
-      def read_pam_frame(io)
-        header = {}
-        line = io.gets
-        return nil unless line && line.delete("\r\n\0") == "P7"
-
-        line = io.gets
-        return nil unless line
-
-        until line.delete("\r\n\0") == "ENDHDR"
-          clean = line.delete("\r\n\0")
-          key, val = clean.split(" ", 2)
-          header[key] = val
-          line = io.gets
-          return nil unless line
-        end
-
-        width = header["WIDTH"].to_i
-        height = header["HEIGHT"].to_i
-        depth = header["DEPTH"].to_i
-        maxval = header["MAXVAL"].to_i
-        bits = Math.log2(maxval + 1).to_i
-        bytes = width * height * depth * (bits / 8)
-        raw = io.read(bytes)
-        return nil unless raw && raw.bytesize == bytes
-
-        buf = Image::Buffer.new([width, height], bits, depth, IO::Buffer.for(raw))
-        Image.from_buffer(buf)
       end
     end
   end

--- a/spec/codec/pam_spec.rb
+++ b/spec/codec/pam_spec.rb
@@ -22,4 +22,15 @@ RSpec.describe ImageUtil::Codec::Pam do
     img = ImageUtil::Image.new(1,1, channels: 2)
     ->{ described_class.encode(:pam, img) }.should raise_error(ArgumentError)
   end
+
+  it 'decodes multiple frames from an IO stream' do
+    img1 = ImageUtil::Image.new(1, 1) { ImageUtil::Color[0, 0, 0] }
+    img2 = ImageUtil::Image.new(1, 1) { ImageUtil::Color[255, 255, 255] }
+    data = described_class.encode(:pam, img1) + described_class.encode(:pam, img2)
+    io = StringIO.new(data)
+    f1 = described_class.decode_frame(io)
+    f2 = described_class.decode_frame(io)
+    f1[0, 0].should == ImageUtil::Color[0, 0, 0, 255]
+    f2[0, 0].should == ImageUtil::Color[255, 255, 255, 255]
+  end
 end


### PR DESCRIPTION
## Summary
- extend Pam codec with `decode_frame` for reading from streams
- use `decode_frame` in ImageMagick codec
- test reading multiple PAM frames from a stream
- document change in CHANGELOG

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_6883a3ba07bc832a9455ec026506fe7f