### PR TITLE
Improve branch coverage

### DIFF
--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -86,6 +86,25 @@ RSpec.describe ImageUtil::Image do
     img[1,0].should == ImageUtil::Color[1,1,1]
   end
 
+  it 'counts pixels in a region' do
+    img = described_class.new(2,2)
+    img.pixel_count([0..1,0..0]).should == 2
+  end
+
+  it 'returns enumerators when no block is given' do
+    img = described_class.new(2,1) { |x| ImageUtil::Color[x] }
+    enum = img.each_pixel
+    enum.should be_a(Enumerator)
+    enum.map(&:r).should == [0, 1]
+
+    img2 = described_class.new(2,1)
+    enum2 = img2.set_each_pixel_by_location!
+    enum2.should be_a(Enumerator)
+    enum2.size.should == 2
+    enum2.each { |loc| ImageUtil::Color[loc.first] }
+    img2[1,0].should == ImageUtil::Color[1,1,1]
+  end
+
   it 'expands locations with nil bounds' do
     img = described_class.new(2,2)
     counts, locs = img.location_expand([nil..1, 0..nil])
@@ -126,6 +145,13 @@ RSpec.describe ImageUtil::Image do
       f.rewind
       other = described_class.from_file(f, :pam)
       other[0,0].should == ImageUtil::Color[4,5,6,255]
+    end
+  end
+
+  it 'requires format when writing to an IO' do
+    img = described_class.new(1,1)
+    Tempfile.create('img') do |f|
+      -> { img.to_file(f) }.should raise_error(ArgumentError)
     end
   end
 

--- a/spec/terminal_spec.rb
+++ b/spec/terminal_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe ImageUtil::Terminal do
       allow(described_class).to receive(:query_terminal).and_return(false, true)
       described_class.detect_support(termin, termout).should == %i[tty sixel]
     end
+
+    it 'caches support results' do
+      allow(described_class).to receive(:query_terminal).and_return(false)
+      described_class.detect_support(termin, termout).should == %i[tty]
+      described_class.should_not_receive(:query_terminal)
+      described_class.detect_support(termin, termout).should == %i[tty]
+    end
   end
 
   describe '.output_image' do
@@ -34,6 +41,20 @@ RSpec.describe ImageUtil::Terminal do
       allow(described_class).to receive(:detect_support).and_return(%i[tty sixel])
       img.should_receive(:to_string).with(:sixel).and_return('S')
       described_class.output_image(termin, termout, img).should == 'S'
+    end
+  end
+
+  describe '.query_terminal' do
+    it 'returns false when reading fails' do
+      failing_termin = Object.new
+      def failing_termin.raw
+        raise EOFError
+      end
+      termout = Object.new.tap do |o|
+        def o.write(*) end
+        def o.flush; end
+      end
+      described_class.query_terminal(failing_termin, termout, 'Q') { true }.should be false
     end
   end
 end


### PR DESCRIPTION
## Summary
- add caching and error handling specs for terminal
- test enumerators and pixel counting in image specs
- enforce format requirement for IO output

## Testing
- `bundle exec rubocop`
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_6883f5f75b00832aa127d4a1ffc733b9