### PR TITLE
Add define_mutable_version and bang filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+- Add `define_mutable_version` helper to create bang versions from immutable
+  methods
+- Add `background!` and `resize!` filters
+
 ## [0.3.0] - 2025-07-25
 - Rename `dither!` to `palette_reduce!`
 - Rename `#set_each_pixel_by_location` to `#set_each_pixel_by_location!` since it's mutable

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Flatten an RGBA image on a solid color.
 img = ImageUtil::Image.new(128, 128) { |x, y| [255, 0, 0, x + y] }
 
 # put it on a blue background
-img.background([0, 0, 255])
+img.background!([0, 0, 255])
+# img.background([0, 0, 255]) # returns a new image
 ```
 
 ![Background example](docs/samples/background.png)
@@ -216,6 +217,7 @@ Scale an image to new dimensions.
 img = ImageUtil::Image.new(128, 128) { |x, y| [x, y, 30] }
 img[20, 20] = img.resize(64, 64)
 img
+# img.resize!(64, 64) # modifies in place
 ```
 
 ![Resize example](docs/samples/resize.png)

--- a/lib/image_util/filter/_mixin.rb
+++ b/lib/image_util/filter/_mixin.rb
@@ -11,6 +11,15 @@ module ImageUtil
         end
       end
 
+      def define_mutable_version(*names)
+        names.each do |name|
+          define_method("#{name}!") do |*args, **kwargs, &block|
+            initialize_from_buffer(public_send(name, *args, **kwargs, &block).buffer)
+            self
+          end
+        end
+      end
+
       def axis_to_number(axis)
         axis = 0 if axis == :x
         axis = 1 if axis == :y

--- a/lib/image_util/filter/background.rb
+++ b/lib/image_util/filter/background.rb
@@ -3,6 +3,7 @@
 module ImageUtil
   module Filter
     module Background
+      extend ImageUtil::Filter::Mixin
       def background(bgcolor)
         return self if channels == 3
 
@@ -18,6 +19,8 @@ module ImageUtil
         end
         img
       end
+
+      define_mutable_version :background
     end
   end
 end

--- a/lib/image_util/filter/resize.rb
+++ b/lib/image_util/filter/resize.rb
@@ -3,6 +3,7 @@
 module ImageUtil
   module Filter
     module Resize
+      extend ImageUtil::Filter::Mixin
       def resize(*new_dimensions, view: View::Interpolated)
         src = self.view(view)
 
@@ -15,6 +16,8 @@ module ImageUtil
           src[*src_loc]
         end
       end
+
+      define_mutable_version :resize
     end
   end
 end

--- a/spec/filter/background_spec.rb
+++ b/spec/filter/background_spec.rb
@@ -20,4 +20,13 @@ RSpec.describe ImageUtil::Image do
       -> { img.background(ImageUtil::Color[0]) }.should raise_error(ArgumentError)
     end
   end
+
+  describe '#background!' do
+    it 'flattens the image in place' do
+      img = described_class.new(1, 1) { ImageUtil::Color[255, 0, 0, 128] }
+      img.background!(ImageUtil::Color[0, 0, 255])
+      img.channels.should == 3
+      img[0, 0].should == ImageUtil::Color.new(128.0, 0.0, 127.0)
+    end
+  end
 end

--- a/spec/filter/resize_spec.rb
+++ b/spec/filter/resize_spec.rb
@@ -26,4 +26,13 @@ RSpec.describe ImageUtil::Image do
       out[0, 0, 1].r.should be_within(0.1).of(50)
     end
   end
+
+  describe '#resize!' do
+    it 'changes image dimensions in place' do
+      img = described_class.new(1, 1) { ImageUtil::Color[1] }
+      img.resize!(2, 2)
+      img.dimensions.should == [2, 2]
+      img[1, 1].should == ImageUtil::Color[1]
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- add `define_mutable_version` to filter mixin for generating bang methods
- use it for `Background#background!` and `Resize#resize!`
- document the new methods
- test mutable background and resize

## Testing
- `bundle exec rake spec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_68841cf79d80832ab9ee3ed965143e41