### PR TITLE
Add iTerm2 inline image support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Add `define_mutable_version` helper to create bang versions from immutable
   methods
 - Add `background!` and `resize!` filters
+- Support iTerm2 inline image protocol
 
 ## [0.3.0] - 2025-07-25
 - Rename `dither!` to `palette_reduce!`

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ just evaluate the object:
 img
 ```
 
-The library checks if the Kitty graphics protocol is available and falls back to SIXEL otherwise. Kitty graphics protocol is supported by Kitty, Konsole
+The library checks if the Kitty graphics protocol is available, then the iTerm2 inline image protocol and falls back to SIXEL otherwise. Kitty graphics protocol is supported by Kitty, Konsole
 and a couple others. SIXEL, most notably, works in Windows Terminal, Konsole (KDE), iTerm2 (macOS), XTerm (launch with: `xterm -ti vt340`). Here's how SIXEL
 looks in Konsole:
 

--- a/lib/image_util/codec.rb
+++ b/lib/image_util/codec.rb
@@ -108,9 +108,11 @@ module ImageUtil
     autoload :ImageMagick, "image_util/codec/image_magick"
     autoload :RubySixel, "image_util/codec/ruby_sixel"
     autoload :Kitty, "image_util/codec/kitty"
+    autoload :ITerm2, "image_util/codec/iterm2"
 
     register_codec :Pam, :pam
     register_codec :Kitty, :kitty
+    register_codec :ITerm2, :iterm2
     register_codec :Libpng, :png
     register_codec :Libturbojpeg, :jpeg
     register_encoder :Libsixel, :sixel

--- a/lib/image_util/codec/iterm2.rb
+++ b/lib/image_util/codec/iterm2.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module ImageUtil
+  module Codec
+    module ITerm2
+      SUPPORTED_FORMATS = [:iterm2].freeze
+
+      extend Guard
+
+      module_function
+
+      def supported?(format = nil)
+        return true if format.nil?
+
+        SUPPORTED_FORMATS.include?(format.to_s.downcase.to_sym)
+      end
+
+      def encode(format, image, options: nil)
+        guard_supported_format!(format, SUPPORTED_FORMATS)
+        guard_image_class!(image)
+        guard_8bit_colors!(image)
+        raise ArgumentError, "only 1d or 2d images supported" if image.dimensions.length > 2
+
+        img = image
+        img = img.redimension(img.width, 1) if img.dimensions.length == 1
+
+        data = Codec.encode(:png, img)
+        encoded = Base64.strict_encode64(data)
+
+        opts = options&.map { |k, v| "#{k}=#{v}" }&.join(";")
+        opts = opts ? "#{opts};inline=1" : "inline=1"
+
+        "\e]1337;File=#{opts}:#{encoded}\a".b
+      end
+
+      def decode(*)
+        raise UnsupportedFormatError, "decode not supported for iterm2"
+      end
+    end
+  end
+end

--- a/lib/image_util/terminal.rb
+++ b/lib/image_util/terminal.rb
@@ -13,6 +13,7 @@ module ImageUtil
       return supported if supported
 
       supported = [:tty]
+      supported << :iterm2 if ENV["TERM_PROGRAM"] == "iTerm.app" || ENV.key?("ITERM_SESSION_ID")
 
       # Send kitty query
       query_terminal(termin, termout, "\e_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\e\\\e[c".b) do |resp|
@@ -53,6 +54,8 @@ module ImageUtil
 
       if support.include? :kitty
         image.to_string(:kitty)
+      elsif support.include? :iterm2
+        image.to_string(:iterm2)
       elsif support.include? :sixel
         image.to_string(:sixel)
       end

--- a/spec/codec/iterm2_spec.rb
+++ b/spec/codec/iterm2_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe ImageUtil::Codec::ITerm2 do
+  it 'encodes an image to the iterm2 protocol' do
+    img = ImageUtil::Image.new(1, 1) { ImageUtil::Color[255, 0, 0] }
+    data = described_class.encode(:iterm2, img)
+    data.start_with?("\e]1337;File=").should be true
+    data.end_with?("\a").should be true
+  end
+
+  it 'encodes 1d images' do
+    img = ImageUtil::Image.new(2) { |loc| ImageUtil::Color[loc.first * 100, 0, 0] }
+    data = described_class.encode(:iterm2, img)
+    data.start_with?("\e]1337;File=").should be true
+  end
+
+  it 'raises on bad input' do
+    img = ImageUtil::Image.new(1, 1, 1)
+    -> { described_class.encode(:iterm2, img) }.should raise_error(ArgumentError)
+    img = ImageUtil::Image.new(1, 1, color_bits: 16)
+    -> { described_class.encode(:iterm2, img) }.should raise_error(ArgumentError)
+    img = ImageUtil::Image.new(1, 1)
+    -> { described_class.encode(:foo, img) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
+  end
+
+  it 'does not support decoding' do
+    -> { described_class.decode(:iterm2, '') }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
+    -> { ImageUtil::Codec.decode_io(:iterm2, StringIO.new, codec: described_class) }.should raise_error(ImageUtil::Codec::UnsupportedFormatError)
+  end
+end

--- a/spec/terminal_spec.rb
+++ b/spec/terminal_spec.rb
@@ -20,6 +20,19 @@ RSpec.describe ImageUtil::Terminal do
       described_class.detect_support(termin, termout).should == %i[tty sixel]
     end
 
+    it 'detects iterm2 support' do
+      allow(described_class).to receive(:query_terminal).and_return(false, false)
+      termout.remove_instance_variable(:@imageutil_support_cache) if termout.instance_variable_defined?(:@imageutil_support_cache)
+      begin
+        orig = ENV['TERM_PROGRAM']
+        ENV['TERM_PROGRAM'] = 'iTerm.app'
+        described_class.detect_support(termin, termout).should include(:iterm2)
+      ensure
+        ENV['TERM_PROGRAM'] = orig
+        termout.remove_instance_variable(:@imageutil_support_cache) if termout.instance_variable_defined?(:@imageutil_support_cache)
+      end
+    end
+
     it 'caches support results' do
       allow(described_class).to receive(:query_terminal).and_return(false)
       described_class.detect_support(termin, termout).should == %i[tty]
@@ -34,6 +47,13 @@ RSpec.describe ImageUtil::Terminal do
       allow(described_class).to receive(:detect_support).and_return(%i[tty kitty])
       img.should_receive(:to_string).with(:kitty).and_return('K')
       described_class.output_image(termin, termout, img).should == 'K'
+    end
+
+    it 'uses iterm2 when kitty is not available' do
+      img = ImageUtil::Image.new(1, 1)
+      allow(described_class).to receive(:detect_support).and_return(%i[tty iterm2])
+      img.should_receive(:to_string).with(:iterm2).and_return('I')
+      described_class.output_image(termin, termout, img).should == 'I'
     end
 
     it 'uses sixel when kitty is not available' do


### PR DESCRIPTION
## Summary
- support the iTerm2 inline image protocol
- detect iTerm2 terminals in `Terminal.detect_support`
- choose the iTerm2 codec when outputting images
- document the new feature
- cover `ITerm2` codec and terminal detection

## Testing
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_688ab11afefc832abbc134cd4b607195